### PR TITLE
Add ARIA to dates

### DIFF
--- a/content/notes/2024-01-16-19-43-56-untitled/index.md
+++ b/content/notes/2024-01-16-19-43-56-untitled/index.md
@@ -5,6 +5,7 @@ note_id: 7
 original_url: https://harper.micro.blog/2024/01/16/hxlt.html
 sub_title: Untitled
 title: 'Note #7'
+aria-label: "Date: 2024-01-16"
 ---
 
 HXLT

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,7 +7,7 @@
     <li>
         <span>
             <i>
-                <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate>
+                <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate aria-label="Date: {{ .Date.Format (default "2006-01-02" .Site.Params.dateFormat) }}">
                     {{ .Date.Format (default "2006-01-02"
                     .Site.Params.dateFormat) }}
                 </time>
@@ -34,7 +34,7 @@
     <li>
         <span>
             <i>
-                <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate>
+                <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate aria-label="Date: {{ .Date.Format (default "2006-01-02" .Site.Params.dateFormat) }}">
                     {{ .Date.Format (default "2006-01-02"
                     .Site.Params.dateFormat) }}
                 </time>

--- a/layouts/notes/list.html
+++ b/layouts/notes/list.html
@@ -10,7 +10,7 @@
         {{ range $paginator.Pages }}
         <article class="post">
             <header>
-                <time datetime='{{ .Date.Format "2006-01-02" }}'>
+                <time datetime='{{ .Date.Format "2006-01-02" }}' aria-label="Date: {{ .Date.Format (default "2006-01-02" .Site.Params.dateFormat) }}">
                     {{ .Date.Format "Jan 02, 2006" }}
                 </time>
                  <a href="{{ .RelPermalink }}" title="Permalink to this note">#</a>

--- a/layouts/notes/single.html
+++ b/layouts/notes/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }} {{ if not .Params.menu }}
 <h1>{{ .Title }}</h1>
 <p class="byline">
-    <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate>
+    <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate aria-label="Date: {{ .Date.Format (default "2006-01-02" .Site.Params.dateFormat) }}">
         {{ .Date.Format (default "2006-01-02" .Site.Params.dateFormat) }}
     </time>
     {{ with .Params.author }}· {{.}}{{ end }}

--- a/layouts/post/list.html
+++ b/layouts/post/list.html
@@ -10,7 +10,7 @@
     <li>
       <span>
         <i>
-          <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate>
+          <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate aria-label="Date: {{ .Date.Format (default "2006-01-02" .Site.Params.dateFormat) }}">
             {{ .Date.Format (default "2006-01-02" .Site.Params.dateFormat) }}
           </time>
         </i>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -4,7 +4,7 @@
 {{ if not .Params.menu }}
 <h1>{{ .Title }}</h1>
 <p class="byline">
-  <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate>
+  <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate aria-label="Date: {{ .Date.Format (default "2006-01-02" .Site.Params.dateFormat) }}">
     {{ .Date.Format (default "2006-01-02" .Site.Params.dateFormat) }}
   </time>
   {{ with .Params.author }}· {{.}}{{ end }} &middot;


### PR DESCRIPTION
Fixes #50

Improve date formatting accessibility by adding ARIA attributes to various layout files and a content file.

* **`layouts/index.html`**: Add `aria-label` attribute to the `<time>` element for date formatting accessibility.
* **`content/notes/2024-01-16-19-43-56-untitled/index.md`**: Add `aria-label` attribute to the `date` front matter for accessibility.
* **`layouts/notes/list.html`**: Add `aria-label` attribute to the `<time>` element for date formatting accessibility.
* **`layouts/notes/single.html`**: Add `aria-label` attribute to the `<time>` element for date formatting accessibility.
* **`layouts/post/single.html`**: Add `aria-label` attribute to the `<time>` element for date formatting accessibility.
* **`layouts/post/list.html`**: Add `aria-label` attribute to the `<time>` element for date formatting accessibility.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/harper.blog/issues/50?shareId=XXXX-XXXX-XXXX-XXXX).