### PR TITLE
Add dark mode support using prefers-color-scheme

### DIFF
--- a/assets/css/harper.css
+++ b/assets/css/harper.css
@@ -38,6 +38,21 @@
     --color-code-bg: #e2e2e2;
 }
 
+@media (prefers-color-scheme: dark) {
+    :root {
+        --color-dark: #fafafa;
+        --color-light: #181a20;
+        --color-primary: #e2e2e2;
+        --color-secondary: #60a5fa;
+        --color-tertiary: #2a2d37;
+        --color-link: #60a5fa;
+        --color-link-visited: #93c5fd;
+        --color-link-hover: #fafafa;
+        --color-code-fg: #181a20;
+        --color-code-bg: #e2e2e2;
+    }
+}
+
 /* Nature Theme */
 .theme-nature2 {
     --color-dark: #2c392f;
@@ -429,7 +444,7 @@ ul.now-posts li a:visited {
     object-fit: cover;
     padding: var(--margin);
     background-color: white;
-    border: 1px solid var(--color-tertiary);
+    border: 1px solid var (--color-tertiary);
     border-radius: 5px;
 }
 

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -20,6 +20,9 @@ class ThemeManager {
 
         // Apply the saved theme on initialization
         this.applyTheme(this.currentTheme);
+
+        // Check for prefers-color-scheme and apply dark theme if preferred
+        this.applyPreferredColorScheme();
     }
 
     // Get list of available themes
@@ -97,6 +100,14 @@ class ThemeManager {
     setRandomTheme() {
         const randomIndex = Math.floor(Math.random() * this.themes.length);
         return this.applyTheme(this.themes[randomIndex]);
+    }
+
+    // Apply preferred color scheme based on user preference
+    applyPreferredColorScheme() {
+        const prefersDarkScheme = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        if (prefersDarkScheme && this.currentTheme === "default") {
+            this.applyTheme("dark");
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #52

Add dark mode support using `prefers-color-scheme`.

* **CSS Changes:**
  - Add `prefers-color-scheme` media query in `assets/css/harper.css` to apply dark theme when user prefers dark color scheme.
  - Ensure existing dark theme styles are included within the `prefers-color-scheme` media query.

* **JavaScript Changes:**
  - Modify `ThemeManager` class in `assets/js/theme.js` to check for `prefers-color-scheme` and apply dark theme if user prefers dark color scheme.
  - Add `applyPreferredColorScheme` method to handle automatic dark mode application based on user preference.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/harper.blog/pull/62?shareId=7980b756-ae38-4c00-a603-0fe55b155f33).