### PR TITLE
Improve description field processing in grab_micro_posts.py

### DIFF
--- a/tools/grab_micro_posts.py
+++ b/tools/grab_micro_posts.py
@@ -102,7 +102,7 @@ def create_hugo_content(entry, output_dir, note_id):
     post = frontmatter.loads(content)
     post['title'] = title
     post['sub_title'] = sub_title
-    post['description'] = content
+    post['description'] = create_description(content)
     post['date'] = date
     post['draft'] = False
     post['original_url'] = post_url
@@ -113,6 +113,16 @@ def create_hugo_content(entry, output_dir, note_id):
 
     print(f"Created new post: {file_path} with Note ID: {note_id}")
     return True
+
+def create_description(content, max_length=160):
+    # Strip markdown syntax
+    clean_content = re.sub(r'[#*`_~\[\]\(\)!]', '', content)
+    # Normalize whitespace
+    clean_content = ' '.join(clean_content.split())
+    # Truncate and add ellipsis if needed
+    if len(clean_content) > max_length:
+        return clean_content[:max_length-3] + '...'
+    return clean_content
 
 def main():
     json_feed_url = os.getenv('NOTES_JSON_FEED_URL')


### PR DESCRIPTION
Fixes #51

Improve description field processing in `tools/grab_micro_posts.py`.

* Add a new function `create_description` to clean up the description field.
  * Strip markdown syntax.
  * Normalize whitespace.
  * Limit description length to 160 characters and add ellipsis if needed.
* Update `post['description']` assignment to use `create_description` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/harper.blog/pull/63?shareId=08317f00-33d3-44d8-9688-ec434d07a5ca).