### PR TITLE
Fix CSP issue

### DIFF
--- a/config/_default/security.toml
+++ b/config/_default/security.toml
@@ -1,0 +1,5 @@
+[security]
+contentSecurityPolicy = """
+default-src 'self';
+connect-src 'self' https://bsky.social;
+"""

--- a/netlify.toml
+++ b/netlify.toml
@@ -29,7 +29,7 @@ command = " hugo --cleanDestinationDir --templateMetrics --templateMetricsHints 
     X-Frame-Options = "deny"
     Referrer-Policy = "no-referrer"
     Feature-Policy = "microphone 'none'; payment 'none'; geolocation 'none'; midi 'none'; sync-xhr 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'"
-    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https:;"
+    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https:; connect-src 'self' https://bsky.social;"
     X-XSS-Protection = "1; mode=block"
     
     [[headers]]


### PR DESCRIPTION
Fixes #65

Update the Content Security Policy (CSP) directive to allow connection to 'https://bsky.social'.

* Add `config/_default/security.toml` with updated CSP directive including 'connect-src' with 'https://bsky.social'.
* Modify `netlify.toml` to include 'connect-src' directive with 'https://bsky.social' in the CSP.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/harper.blog/pull/66?shareId=3cb6853e-d4c9-4612-b12b-f81a4b87d2f6).