### PR TITLE
Add alternative grid view for books

### DIFF
--- a/assets/css/books.css
+++ b/assets/css/books.css
@@ -20,3 +20,17 @@
     text-decoration: none;
     speak: none;
 }
+
+.book-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 20px;
+}
+
+.book-item {
+    background-color: #f9f9f9;
+    border: 1px solid #ddd;
+    padding: 10px;
+    border-radius: 5px;
+    text-align: center;
+}

--- a/content/books/_index.md
+++ b/content/books/_index.md
@@ -8,3 +8,5 @@ url: /media/books
 ---
 
 I read a lot of books. Here is my read book list.
+
+[View books in grid format](/books/grid)

--- a/layouts/books/grid.html
+++ b/layouts/books/grid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Books Grid View</title>
+    <link rel="stylesheet" href="/assets/css/books.css">
+</head>
+<body>
+    <div class="book-grid">
+        {{ range .Pages }}
+        <div class="book-item">
+            <a href="{{ .Permalink }}">
+                <img src="{{ .Params.image }}" alt="{{ .Title }}">
+                <h2>{{ .Title }}</h2>
+                <p>{{ .Params.author }}</p>
+            </a>
+        </div>
+        {{ end }}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Add an alternative grid view for the books content type.

* Add `.book-grid` and `.book-item` classes in `assets/css/books.css` for grid layout styling.
* Create a new layout template `layouts/books/grid.html` to render books in a grid format.
* Update `content/books/_index.md` to include a link to the new grid view.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/harper.blog/pull/91?shareId=8d14d1f5-d54d-48ef-832f-3269336d7f37).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a grid view for books with improved visual presentation
	- Introduced a new navigation link to view books in grid format

- **Style**
	- Created new CSS classes for book grid and book item layouts
	- Implemented responsive grid design with consistent book item styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->