### PR TITLE
🔒 security: disable unsafe HTML rendering in markup config

### DIFF
--- a/config/_default/markup.toml
+++ b/config/_default/markup.toml
@@ -1,7 +1,7 @@
 
 ############################ Markup ##############################
 [goldmark.renderer]
-unsafe = true
+unsafe = false
 
 [highlight]
 style = 'monokai' # see https://xyproto.github.io/splash/docs/all.html


### PR DESCRIPTION
Fixes #107

This PR addresses a critical security vulnerability by disabling unsafe HTML rendering in the Hugo markup configuration.

## Changes
- Set `unsafe = false` in `config/_default/markup.toml`
- Prevents potential XSS vulnerabilities from malicious HTML/JS injection

## Impact
This change enhances security by preventing arbitrary HTML/JavaScript execution through markdown content. Any content requiring trusted HTML should use Hugo shortcodes instead.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated content rendering settings to enhance security by disallowing potentially unsafe elements in the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->