### PR TITLE
fix: update Go version from 1.19 to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harperreed/harper.blog
 
-go 1.19
+go 1.21
 
 require (
 	github.com/clente/hugo-bearcub v0.0.0-20250119144833-c3286b77b8e2 // indirect


### PR DESCRIPTION
Updates Go version from 1.19 to 1.21 to address:

- Security patches and vulnerability fixes
- Performance improvements
- Better toolchain support
- Hugo compatibility

Resolves #110

Generated with [Claude Code](https://claude.ai/code)