### PR TITLE
fix: replace removed .Site.Author with .Site.Params.author

### DIFF
--- a/layouts/_default/media.rss.xml
+++ b/layouts/_default/media.rss.xml
@@ -27,8 +27,8 @@
     <description>Recent media activity including books, music, and links from {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>
     {{ with .Site.LanguageCode }}<language>{{.}}</language>{{end}}
-    {{ with .Site.Author.email }}<managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}
-    {{ with .Site.Author.email }}<webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}
+    {{ with .Site.Params.author.email }}<managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}
+    {{ with .Site.Params.author.email }}<webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}
     {{ if not .Date.IsZero }}<lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
     {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
@@ -50,7 +50,7 @@
         <link>{{ .Params.original_url | default .Permalink }}</link>
       {{- end }}
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ with .Description }}{{ . }}{{ else }}{{ .Summary | html }}{{ end }}</description>
       <content:encoded>

--- a/layouts/books/rss.xml
+++ b/layouts/books/rss.xml
@@ -12,8 +12,8 @@
     <description>Recent Books{{ if ne .Title .Site.Title }} on {{ .Site.Title }}{{ end }}</description>
     <generator>Hugo -- gohugo.io</generator>
     {{ with .Site.LanguageCode }}<language>{{ . }}</language>{{ end }}
-    {{ with .Site.Author.email }}<managingEditor>{{ . }}{{ with $.Site.Author.name }} ({{ . }}){{ end }}</managingEditor>{{ end }}
-    {{ with .Site.Author.email }}<webMaster>{{ . }}{{ with $.Site.Author.name }} ({{ . }}){{ end }}</webMaster>{{ end }}
+    {{ with .Site.Params.author.email }}<managingEditor>{{ . }}{{ with $.Site.Params.author.name }} ({{ . }}){{ end }}</managingEditor>{{ end }}
+    {{ with .Site.Params.author.email }}<webMaster>{{ . }}{{ with $.Site.Params.author.name }} ({{ . }}){{ end }}</webMaster>{{ end }}
     {{ with .Site.Copyright }}<copyright>{{ . }}</copyright>{{ end }}
     {{ if not .Date.IsZero }}<lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
@@ -38,7 +38,7 @@
         <link>{{ .Permalink }}</link>
         {{ end }}
         <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-        {{ with .Site.Author.email }}<author>{{ . }}{{ with $.Site.Author.name }} ({{ . }}){{ end }}</author>{{ end }}
+        {{ with .Site.Params.author.email }}<author>{{ . }}{{ with $.Site.Params.author.name }} ({{ . }}){{ end }}</author>{{ end }}
         <guid>{{ .Permalink }}</guid>
         {{ with .Params.book_author }}<dc:creator>{{ . }}</dc:creator>{{ end }}
         {{- /* Book cover as media content */ -}}

--- a/layouts/index.linksrss.xml
+++ b/layouts/index.linksrss.xml
@@ -6,9 +6,9 @@
     <link>{{ .Permalink }}</link>
     <description>Recent links from {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Params.author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.email }}
+    <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "LinksRSS" }}
@@ -33,7 +33,7 @@
         <title>{{ .Content | plainify | htmlUnescape }}</title>
         <link>{{ .Params.original_url }}</link>
         <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-        {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+        {{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
         <guid>{{ .Permalink }}</guid>
         {{ $url := urls.Parse .Params.original_url}}
         <description><![CDATA[{{ .Content | plainify | htmlUnescape }} ({{ $url.Host }})<img src="https://tinylytics.app/pixel/WV5Khk7ZG6MZe6q49ikx.gif" alt="" width="1" height="1" />]]></description>

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -48,11 +48,11 @@
     <generator>Hugo -- gohugo.io</generator>
     {{ with .Site.LanguageCode }}
     <language>{{.}}</language>{{end}}
-    {{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>
+    {{ with .Site.Params.author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>
     {{end}}
-    {{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>
+    {{ with .Site.Params.author.email }}
+    <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>
     {{end}}
     {{ with .Site.Copyright }}
     <copyright>{{ . | markdownify | plainify }}</copyright>
@@ -75,9 +75,9 @@
                 <pubDate>
                     {{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}
                 </pubDate>
-                {{- with .Site.Author.email }}
+                {{- with .Site.Params.author.email }}
                     <author>
-                        {{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}
+                        {{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}
                     </author>
                 {{ end }}
                 <guid>{{ .Permalink }}</guid>

--- a/layouts/links/rss.xml
+++ b/layouts/links/rss.xml
@@ -11,8 +11,8 @@
     <description>Recent Links{{ if ne .Title .Site.Title }} on {{ .Site.Title }}{{ end }} - Curated articles and interesting reads</description>
     <generator>Hugo -- gohugo.io</generator>
     {{ with .Site.LanguageCode }}<language>{{ . }}</language>{{ end }}
-    {{ with .Site.Author.email }}<managingEditor>{{ . }}{{ with $.Site.Author.name }} ({{ . }}){{ end }}</managingEditor>{{ end }}
-    {{ with .Site.Author.email }}<webMaster>{{ . }}{{ with $.Site.Author.name }} ({{ . }}){{ end }}</webMaster>{{ end }}
+    {{ with .Site.Params.author.email }}<managingEditor>{{ . }}{{ with $.Site.Params.author.name }} ({{ . }}){{ end }}</managingEditor>{{ end }}
+    {{ with .Site.Params.author.email }}<webMaster>{{ . }}{{ with $.Site.Params.author.name }} ({{ . }}){{ end }}</webMaster>{{ end }}
     {{ with .Site.Copyright }}<copyright>{{ . }}</copyright>{{ end }}
     {{ if not .Date.IsZero }}<lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
@@ -35,7 +35,7 @@
         <link>{{ .Permalink }}</link>
         {{ end }}
         <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-        {{ with .Site.Author.email }}<author>{{ . }}{{ with $.Site.Author.name }} ({{ . }}){{ end }}</author>{{ end }}
+        {{ with .Site.Params.author.email }}<author>{{ . }}{{ with $.Site.Params.author.name }} ({{ . }}){{ end }}</author>{{ end }}
         <guid>{{ .Permalink }}</guid>
         {{- /* Source as dc:source */ -}}
         {{ with .Params.original_url }}

--- a/layouts/music/rss.xml
+++ b/layouts/music/rss.xml
@@ -12,8 +12,8 @@
     <description>Recent Music{{ if ne .Title .Site.Title }} on {{ .Site.Title }}{{ end }}</description>
     <generator>Hugo -- gohugo.io</generator>
     {{ with .Site.LanguageCode }}<language>{{ . }}</language>{{ end }}
-    {{ with .Site.Author.email }}<managingEditor>{{ . }}{{ with $.Site.Author.name }} ({{ . }}){{ end }}</managingEditor>{{ end }}
-    {{ with .Site.Author.email }}<webMaster>{{ . }}{{ with $.Site.Author.name }} ({{ . }}){{ end }}</webMaster>{{ end }}
+    {{ with .Site.Params.author.email }}<managingEditor>{{ . }}{{ with $.Site.Params.author.name }} ({{ . }}){{ end }}</managingEditor>{{ end }}
+    {{ with .Site.Params.author.email }}<webMaster>{{ . }}{{ with $.Site.Params.author.name }} ({{ . }}){{ end }}</webMaster>{{ end }}
     {{ with .Site.Copyright }}<copyright>{{ . }}</copyright>{{ end }}
     {{ if not .Date.IsZero }}<lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
@@ -36,7 +36,7 @@
         <link>{{ .Permalink }}</link>
         {{ end }}
         <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-        {{ with .Site.Author.email }}<author>{{ . }}{{ with $.Site.Author.name }} ({{ . }}){{ end }}</author>{{ end }}
+        {{ with .Site.Params.author.email }}<author>{{ . }}{{ with $.Site.Params.author.name }} ({{ . }}){{ end }}</author>{{ end }}
         <guid>{{ .Permalink }}</guid>
         {{- /* Artist metadata */ -}}
         {{ with .Params.artist }}<itunes:author>{{ . }}</itunes:author>{{ end }}

--- a/layouts/partials/schema/article.html
+++ b/layouts/partials/schema/article.html
@@ -3,7 +3,7 @@
 
 {{- if .IsPage -}}
 {{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
-{{- $author := .Params.author | default .Site.Params.author.name | default .Site.Author.name | default "Harper Reed" -}}
+{{- $author := .Params.author | default .Site.Params.author.name | default "Harper Reed" -}}
 {{- $image := "" -}}
 
 {{/* Get featured image */}}

--- a/layouts/partials/schema/person.html
+++ b/layouts/partials/schema/person.html
@@ -1,7 +1,7 @@
 {{/* ABOUTME: Generates JSON-LD Person structured data for author/site owner. */}}
 {{/* ABOUTME: Helps search engines understand the site's authorship and creator. */}}
 
-{{- $author := .Site.Params.author.name | default .Site.Author.name | default "Harper Reed" -}}
+{{- $author := .Site.Params.author.name | default "Harper Reed" -}}
 {{- $email := .Site.Params.author.email | default .Site.Params.email | default "harper@modest.com" -}}
 {{- $avatar := .Site.Params.avatar | default "https://s.gravatar.com/avatar/b7a96b3d5b5cfed5228396104cd67b38?s=400" -}}
 

--- a/layouts/photos/rss.xml
+++ b/layouts/photos/rss.xml
@@ -11,8 +11,8 @@
     <description>Photo posts and snapshots from {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>
     {{ with .Site.LanguageCode }}<language>{{ . }}</language>{{ end }}
-    {{ with .Site.Author.email }}<managingEditor>{{ . }}{{ with $.Site.Author.name }} ({{ . }}){{ end }}</managingEditor>{{ end }}
-    {{ with .Site.Author.email }}<webMaster>{{ . }}{{ with $.Site.Author.name }} ({{ . }}){{ end }}</webMaster>{{ end }}
+    {{ with .Site.Params.author.email }}<managingEditor>{{ . }}{{ with $.Site.Params.author.name }} ({{ . }}){{ end }}</managingEditor>{{ end }}
+    {{ with .Site.Params.author.email }}<webMaster>{{ . }}{{ with $.Site.Params.author.name }} ({{ . }}){{ end }}</webMaster>{{ end }}
     {{ with .Site.Copyright }}<copyright>{{ . }}</copyright>{{ end }}
     <lastBuildDate>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
     {{ with .OutputFormats.Get "RSS" }}
@@ -37,7 +37,7 @@
         <title>{{ with .Title }}{{ . }}{{ else }}Photo Post{{ end }}</title>
         <link>{{ .Permalink }}</link>
         <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-        {{ with $.Site.Author.email }}<author>{{ . }}{{ with $.Site.Author.name }} ({{ . }}){{ end }}</author>{{ end }}
+        {{ with $.Site.Params.author.email }}<author>{{ . }}{{ with $.Site.Params.author.name }} ({{ . }}){{ end }}</author>{{ end }}
         <guid>{{ .Permalink }}</guid>
         {{- /* First image as primary enclosure with required length attribute */ -}}
         {{ $firstImage := index $images 0 }}


### PR DESCRIPTION
## Problem
Building with any Hugo newer than the pinned 0.154.x dies with:
`can't evaluate field Author in type page.Site`

Hugo deprecated `.Site.Author` in 0.124 and has since removed it (homebrew's 0.164 errors hard). The repo's mise/CI/Netlify pin at 0.154.x was masking this.

## Fix
Replace all `.Site.Author.*` references with `.Site.Params.author.*` (set in `params.toml`, already the working pattern in `schema/person.html`):
- `schema/article.html` / `schema/person.html`: drop the dead `default .Site.Author.name` fallback — Go templates evaluate `default` args eagerly, so it exploded even though the Params value always wins
- 7 RSS templates: `.Site.Author.email/.name` → `.Site.Params.author.email/.name`

## Side effect (intended)
`.Site.Author.email` was silently empty even on old Hugo — live feeds have no `managingEditor`. Feeds now emit `harper@modest.com (Harper Reed)` in managingEditor/webMaster/author, which is what these templates always meant to do.

## Verification
- `hugo` (pinned 0.154.1): exit 0 before and after
- `/opt/homebrew/bin/hugo` (0.164.0): exit 1 before → **exit 0 after**
- `public/index.xml` now contains the author tags

## Noted, not fixed here
0.164 warns about `languageCode`/`languageName` config keys (deprecated 0.158, removal future) — separate cleanup for whenever the pin gets bumped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated RSS feeds to consistently display configured author names and email addresses.
  - Improved author metadata across articles, photos, music, books, links, and general site feeds.
  - Updated structured data author fallbacks to use the configured site author information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->