### PR TITLE
fix: video centering + pronounced blockquotes

### DIFF
--- a/assets/css/harper.css
+++ b/assets/css/harper.css
@@ -233,6 +233,13 @@ figure img {
     border-radius: var(--border-radius-base);
 }
 
+/* Videos re-center in the breakout box like images, but skip the photo frame */
+figure video {
+    display: block;
+    margin-inline: auto;
+    max-width: 100%;
+}
+
 @media screen and (max-width: 768px) {
     figure img {
         padding: 0px; /* Smaller padding on mobile */

--- a/assets/css/harper.css
+++ b/assets/css/harper.css
@@ -128,11 +128,22 @@ img {
 }
 
 blockquote {
-    margin-left: 0;
-    border-left: 3px solid var(--color-muted);
+    margin-inline: 0;
+    border-left: 4px solid var(--color-primary);
     color: var(--color-dark);
-    padding: 0 var(--margin) 0 var(--margin-big);
+    padding: var(--margin) var(--margin-big);
     font-style: italic;
+    /* Tint follows each theme's own accent, in light and dark */
+    background: color-mix(in srgb, var(--color-primary) 7%, transparent);
+    border-radius: 0 var(--border-radius-base) var(--border-radius-base) 0;
+}
+
+blockquote > :first-child {
+    margin-block-start: 0;
+}
+
+blockquote > :last-child {
+    margin-block-end: 0;
 }
 
 footer {


### PR DESCRIPTION
Two small follow-ups to #161, both eyeballed on the live tailscale preview.

1. **Center videos inside breakout figures** — #161 widened every `figure` past the text column via negative margins and re-centered `figure img`, but the `{{< video >}}` shortcode's `figure > video` had no rule, so the /now video hugged the left edge of the widened box (visibly left of the text column). Videos now get the same `display: block; margin-inline: auto` as images — without the white photo mat, which belongs on prints, not players. One `{{< video >}}` exists sitewide (/now).
2. **Pronounced blockquotes** — the calm left-rule version blended into body text. Now: 4px accent bar in `--color-primary`, a 7% `color-mix` wash of the same color (so the tint follows each theme's palette in light and dark), soft right-side radius, and first/last-child margin trims so the padding is even.

Verification: served bundle contains both rules; clean hugo 0.164 build; `color-mix` degrades to no background on old engines while the bar still reads as a quote.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated blockquotes with theme-colored accents, improved spacing, translucent backgrounds, and rounded corners.
  - Normalized spacing within blockquote content.
  - Added responsive, centered styling for videos displayed inside figures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->