### PR TITLE
feat: rebuild snapshots page as a justified photo wall

### DIFF
--- a/assets/css/notes-grid.css
+++ b/assets/css/notes-grid.css
@@ -18,8 +18,14 @@
     max-width: 480px;
 }
 
+/* width:auto seeds the flex item's intrinsic width from the photo's aspect
+   ratio at row height — a percentage width here is a "cyclic percentage" whose
+   intrinsic resolution differs across engines. The min/max clamps only apply
+   after layout, making the image fill whatever the item grew (or capped) to. */
 .snap-wall img {
-    width: 100%;
+    width: auto;
+    min-width: 100%;
+    max-width: 100%;
     height: 100%;
     object-fit: cover;
     display: block;

--- a/assets/css/notes-grid.css
+++ b/assets/css/notes-grid.css
@@ -1,84 +1,43 @@
-/* Masonry Columns Container */
-.masonry-columns {
-    column-count: 3;
-    column-gap: 16px;
-    column-fill: balance;
-    width: 100%;
-    margin: 0 auto;
-    padding: 0;
+/* ABOUTME: Justified photo wall for /notes/snapshots/ (layouts/notes/notes-grid.html). */
+/* ABOUTME: Flex rows preserve aspect ratios and read row-major, so newest photos stay on top. */
+
+.snap-wall {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-block-start: var(--margin-big);
+    margin-inline: var(--breakout-margin);
 }
 
-/* Responsive columns */
-@media (max-width: 1200px) {
-    .masonry-columns {
-        column-count: 2;
-    }
+/* Items start at their photo's natural width for the row height, then grow to
+   justify the row; the max-width keeps a sparse last row from stretching one
+   photo absurdly wide. */
+.snap-wall > a {
+    flex-grow: 1;
+    height: 240px;
+    max-width: 480px;
+}
+
+.snap-wall img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    border-radius: var(--border-radius-sm);
 }
 
 @media (max-width: 768px) {
-    .masonry-columns {
-        column-count: 1;
+    .snap-wall > a {
+        height: 150px;
+        max-width: 300px;
     }
 }
 
-/* Masonry Items */
-.masonry-item {
-    break-inside: avoid;
-    margin-bottom: 16px;
-    page-break-inside: avoid;
-    -webkit-column-break-inside: avoid;
-    position: relative;
-    display: block;
-    will-change: transform;
-    transform: translateZ(0);
-}
-
-/* Image Styling */
-.masonry-item img {
-    width: 100%;
-    height: auto;
-    border-radius: 2px;
-    object-fit: cover;
-    display: block;
-    backface-visibility: hidden;
-    -webkit-backface-visibility: hidden;
-    transition: transform 0.3s ease;
-    will-change: transform;
-}
-
-/* Hover effect */
-.masonry-item:hover img {
-    transform: scale(1.02);
-}
-
-/* Fix for Firefox */
-@-moz-document url-prefix() {
-    .masonry-item {
-        display: inline-block;
-        width: 100%;
+@media (prefers-reduced-motion: no-preference) {
+    .snap-wall img {
+        transition: opacity 0.15s ease;
     }
-}
-
-/* Fix for Safari */
-@supports (-webkit-overflow-scrolling: touch) {
-    .masonry-item {
-        -webkit-transform: translate3d(0, 0, 0);
+    .snap-wall > a:hover img {
+        opacity: 0.85;
     }
-}
-
-/* Prevent FOUC */
-.masonry-columns {
-    opacity: 0;
-    animation: fadeIn 0.3s ease forwards;
-}
-
-@keyframes fadeIn {
-    to {
-        opacity: 1;
-    }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .notes-masonry-item { animation: none; transition: none; }
-    .notes-masonry-item:hover { transform: none; }
 }

--- a/layouts/notes/notes-grid.html
+++ b/layouts/notes/notes-grid.html
@@ -1,26 +1,28 @@
-{{ define "main" }} {{ .Content }}
-<div class="masonry-columns">
-    {{ range where .Site.RegularPages "Type" "notes" }} 
-
+{{- /* ABOUTME: Justified photo wall of every image across notes (used by /notes/snapshots/). */}}
+{{- /* ABOUTME: Row-major flex layout so newest photos stay on top; each links to its note. */}}
+{{ define "main" }}
+<header>
+    <h1>{{ .Title }}</h1>
+</header>
+{{ .Content }}
+<div class="snap-wall">
+    {{ range where .Site.RegularPages "Type" "notes" }}
     {{ $pageLink := .Permalink }}
     {{ if ne .Params.exclude true }}
-
     {{ range .Resources.ByType "image" }}
-    <div class="masonry-item">
-        <a href="{{ $pageLink }}">
-            {{ $thumbnail := .Resize "600x" }}
-            <img
-                src="{{ $thumbnail.RelPermalink }}"
-                alt="{{ .Title }}"
-                loading="lazy"
-                width="{{ $thumbnail.Width }}"
-                height="{{ $thumbnail.Height }}"
-            />
-        </a>
-    </div>
-    {{ end }} 
-    {{ end }} 
-    
+    {{ $thumbnail := .Resize "600x" }}
+    <a href="{{ $pageLink }}">
+        <img
+            src="{{ $thumbnail.RelPermalink }}"
+            alt="{{ .Title }}"
+            loading="lazy"
+            decoding="async"
+            width="{{ $thumbnail.Width }}"
+            height="{{ $thumbnail.Height }}"
+        />
+    </a>
+    {{ end }}
+    {{ end }}
     {{ end }}
 </div>
 {{ end }}


### PR DESCRIPTION
Rebuilds /notes/snapshots/ (728 photos), eyeballed and approved on the live tailscale preview.

**Why**: the old CSS-columns masonry flowed column-major — the newest ~240 photos stacked down column 1, so the visible top row was roughly [this week, 8 months ago, 2 years ago]. It also sat squeezed inside the 720px text column while every other gallery breaks out, and rendered no page header at all.

**What**:
- Justified photo wall: flex rows, row-major, so chronology reads like text — newest photo top-left. Aspect ratios preserved at a 240px row height (150px mobile), rows justify edge-to-edge with light `object-fit` crops, 6px gaps. A `max-width` cap keeps a sparse last row from stretching one photo wide.
- Breaks out to `min(1000px, viewport)` via the shared `--breakout-margin`, matching /photos and note grids.
- Proper header (`h1` + intro content), same shape as /photos.
- Cruft removed: dead `@-moz-document` hack, a reduced-motion rule targeting a nonexistent class, `will-change`/`translateZ` incantations, and a FOUC opacity animation that fought the site-wide image fade-in. Hover is a subtle opacity dip wrapped in `prefers-reduced-motion`.
- Every photo still lazy-loads (`decoding=async` added) and still links to its note.

**Verification**: served page has 728 items, zero masonry references, bundle serves the new rules; clean hugo 0.164 rebuild via the dev server. No inline styles (Netlify CSP). Independent of #162 (different files).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the notes image grid as a responsive, justified photo wall.
  * Added a title and page content above the image gallery.
  * Improved image presentation with cropping, rounded corners, rounded edges, and responsive sizing.
* **Accessibility**
  * Reduced-motion preferences now disable hover transitions.
* **Performance**
  * Images continue to load lazily and now decode asynchronously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->