### PR TITLE
Add voice shortcode for dialogue posts

### DIFF
--- a/assets/css/dialogue.css
+++ b/assets/css/dialogue.css
@@ -1,0 +1,34 @@
+/* dialogue voices (voice shortcode) — colors come from theme vars so they survive the per-deploy theme roulette */
+
+.voice {
+    --voice-color: var(--color-primary);
+    border-left: 3px solid var(--voice-color);
+    padding-left: 1rem;
+    margin: 1.5rem 0;
+}
+
+.voice-a {
+    --voice-color: var(--color-link);
+}
+
+.voice-b {
+    --voice-color: var(--color-secondary);
+}
+
+.voice-name {
+    display: block;
+    color: var(--voice-color);
+    font-weight: 700;
+    font-size: 0.85em;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.25rem;
+}
+
+.voice p:first-of-type {
+    margin-top: 0;
+}
+
+.voice p:last-of-type {
+    margin-bottom: 0;
+}

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -53,6 +53,7 @@ customcss = [
     "/css/photos.css",
     "/css/code.css",
     "/css/translations.css",
+    "/css/dialogue.css",
     "syntax.css",
 ]
 

--- a/content/post/2026-08-15-voice-shortcode-demo/index.md
+++ b/content/post/2026-08-15-voice-shortcode-demo/index.md
@@ -1,0 +1,28 @@
+---
+title: Voice shortcode demo
+date: 2026-08-15T12:00:00-05:00
+draft: true
+description: Draft demo of the voice dialogue shortcode — safe to delete once a real post uses it
+tags:
+    - meta
+---
+
+Two characters, back and forth. Slot `a` tints from the theme's link color, slot `b` from its secondary color, so both survive the deploy-time theme roulette.
+
+{{< voice a "Karen" >}}
+You did *what* with the production database?
+{{< /voice >}}
+
+{{< voice b "Dale" >}}
+I renamed it. `db-final-FINAL-2`. For clarity.
+
+Look, the old name had a typo and it was bothering me.
+{{< /voice >}}
+
+{{< voice a "Karen" >}}
+The typo **was** the name, Dale. Every config file on earth points at the typo.
+{{< /voice >}}
+
+{{< voice b >}}
+(An unlabeled voice block still gets the border and color — the label is optional.)
+{{< /voice >}}

--- a/layouts/shortcodes/voice.html
+++ b/layouts/shortcodes/voice.html
@@ -1,0 +1,7 @@
+{{- /* Dialogue voice for back-and-forth posts: {{< voice a "Karen" >}}markdown{{< /voice >}}.
+First arg picks the color slot (a or b), optional second arg is the speaker label. */ -}}
+{{- $slot := .Get 0 | default "a" -}}
+<div class="voice voice-{{ $slot }}">
+    {{- with .Get 1 }}<strong class="voice-name">{{ . }}</strong>{{ end }}
+    {{ .Inner | markdownify }}
+</div>


### PR DESCRIPTION
## What

A paired shortcode for back-and-forth dialogue posts:

```
{{< voice a "Karen" >}}
You did *what* with the production database?
{{< /voice >}}

{{< voice b "Dale" >}}
I renamed it. For clarity.
{{< /voice >}}
```

- First arg picks the color slot: `a` tints from `--color-link`, `b` from `--color-secondary` — theme variables, so both voices stay coherent under the per-deploy theme roulette. No inline styles, so Netlify CSP is happy.
- Second arg is the optional speaker label, rendered as a bold block label. That keeps speakers distinguishable in RSS readers (where classes are stripped) and for colorblind readers — color is an accent, the label and left border carry the structure.
- Markdown works inside the blocks.

Three files: `layouts/shortcodes/voice.html`, `assets/css/dialogue.css`, one line in `params.toml` to register the CSS. Plus a **draft demo post** (`/2026/08/15/voice-shortcode-demo/`) — eyeball it on the preview, then delete it whenever a real post uses the shortcode.

## Verification

Demo page renders correct markup on the dev server (alternating `voice-a`/`voice-b` divs, labels, markdownified inner content) and `dialogue.css` lands in the fingerprinted bundle. The `%!(EXTRA …)` garbage visible in the demo page's language switcher is main's pre-existing bug, fixed separately in #165.

Note: independent of #165 — branched from main, no conflicts expected (different files).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a voice dialogue block for presenting styled character speech.
  * Supports optional speaker labels, Markdown content, and theme-based accent colors.
  * Added a demonstration post showing labeled and unlabeled dialogue examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->