### PR TITLE
Retire the cyberpunk theme

### DIFF
--- a/assets/css/themes.css
+++ b/assets/css/themes.css
@@ -360,34 +360,6 @@
     }
 }
 
-/* Cyberpunk Theme */
-.theme-cyberpunk {
-    --color-dark: #150b29;
-    --color-light: #fcf9ff;
-    --color-primary: #150b29;
-    --color-secondary: #00ffff;
-    --color-tertiary: #e0ffff;
-    --color-link: #00ffff;
-    --color-link-visited: #00cccc;
-    --color-link-hover: #ff00aa;
-    --color-code-fg: #fcf9ff;
-    --color-code-bg: #150b29;
-}
-@media (prefers-color-scheme: dark) {
-    .theme-cyberpunk {
-        --color-dark: #fcf9ff;
-        --color-light: #150b29;
-        --color-primary: #e0ffff;
-        --color-secondary: #00ffff;
-        --color-tertiary: #2b1652;
-        --color-link: #00ffff;
-        --color-link-visited: #66ffff;
-        --color-link-hover: #ff00aa;
-        --color-code-fg: #150b29;
-        --color-code-bg: #e0ffff;
-    }
-}
-
 /* Volcano Theme */
 .theme-volcano {
     --color-dark: #1f0f0f;

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -33,7 +33,6 @@ defaultContentLanguage = "en"
 # theme = "neon"
 # theme = "electric"
 # theme = "volcano"
-# theme = "cyberpunk"
 
 
 customcss = [

--- a/scripts/build_with_random_theme.sh
+++ b/scripts/build_with_random_theme.sh
@@ -20,7 +20,6 @@ THEMES=(
     "halloween"
     "neon"
     "electric"
-    "cyberpunk"
     "volcano"
     "midnight"
     "lavender"


### PR DESCRIPTION
Kills the cyberpunk theme per Harper: https://harper.blog/2026/08/15/fugue-state-love/ rendered with it and was unreadable.

Root cause on main: light mode sets `--color-link: #00ffff` — pure neon cyan on `#fcf9ff` near-white, ~1.25:1 contrast. Links are invisible. Dark mode is cyan-on-black-purple, which passes the WCAG ratio but is still an eye-searing glow.

Removed: the two `themes.css` blocks, the rotation entry in `build_with_random_theme.sh`, and the commented config example. 24 themes remain; built bundle verified free of `theme-cyberpunk`.

Note for merging: PR #167 recolors this same CSS block (its contrast sweep changed the light-mode links to `#007070`). Whichever lands second gets a trivial delete/modify conflict on that hunk — resolve by keeping the deletion.

The live site keeps its current theme until the next deploy; merging this triggers one, which re-rolls from the trimmed list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the Cyberpunk visual theme and its dark-mode variations.
  * Other available themes remain unchanged.

* **Chores**
  * Removed Cyberpunk from theme configuration and random theme selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->