### PR TITLE
fix: related posts show blog posts only

### DIFF
--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -4,7 +4,8 @@
 {{- $postDate := .Date -}}
 {{- $startDate := $postDate.AddDate -5 0 0 -}}
 {{- $endDate := $postDate.AddDate 5 0 0 -}}
-{{- $allRelated := .Site.RegularPages.Related . -}}
+{{- /* Candidates are blog posts only — links/books/music/notes share tags and would crowd out actual posts */ -}}
+{{- $allRelated := (where .Site.RegularPages "Section" "post").Related . -}}
 {{- $related := where (where $allRelated ".Date" "ge" $startDate) ".Date" "le" $endDate | first 5 -}}
 {{- with $related -}}
 <aside class="related-posts" aria-label="{{ i18n "related-posts" }}">


### PR DESCRIPTION
`related-posts.html` fed `.Related` the entire `RegularPages` collection, so tagged links/books/music/notes competed with posts — e.g. the fugue-state post's related box was 5-for-5 links. Candidates are now `Section == "post"` only.

Verified: full-site sweep of the /tmp build finds zero posts with cross-type related items; the partial is only called from `post/single.html`, so nothing else changes. It's live on the tailscale preview on any post page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Related posts now display only content from the post section, improving relevance.
  * Existing date filtering and five-item display limits remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->