### PR TITLE
Audit tranche 3: CI pinning, config leftovers, home-feed img fix

### DIFF
--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -5,6 +5,11 @@ on:
       - main
   workflow_dispatch: # Allow manual triggers
 
+# Rapid pushes to main would otherwise race on the update-authors branch
+concurrency:
+  group: update-authors-${{ github.ref }}
+  cancel-in-progress: true
+
 # Document workflow purpose
 # This workflow automatically updates the AUTHORS file with new contributors
 jobs:
@@ -13,7 +18,7 @@ jobs:
     steps:
       # Check out repository with full history
       - name: Checkout Repository
-        uses: actions/checkout@v3 # Upgrade to v3
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -45,7 +50,7 @@ jobs:
 
       # Create Pull Request if changes exist
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5 # Upgrade to v5
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
         with:
           commit-message: "chore: update AUTHORS file"
           title: "chore: update AUTHORS file with new contributors"

--- a/.github/workflows/check-i18n.yaml
+++ b/.github/workflows/check-i18n.yaml
@@ -25,12 +25,12 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
               with:
                   fetch-depth: 1
 
             - name: Setup uv
-              uses: astral-sh/setup-uv@v5
+              uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
               with:
                   enable-cache: true
                   cache-dependency-glob: "tools/uv.lock"

--- a/.github/workflows/grab_goodreads.yaml
+++ b/.github/workflows/grab_goodreads.yaml
@@ -2,7 +2,7 @@ name: Run Goodreads Read Script
 
 on:
     schedule:
-        - cron: "0 10 * * *" # Runs every 12 hours
+        - cron: "0 10 * * *" # Runs daily at 10:00 UTC
     workflow_dispatch: # Allows manual triggering
 
 # Add concurrency control

--- a/.github/workflows/grab_spotify_saved_tracks.yaml
+++ b/.github/workflows/grab_spotify_saved_tracks.yaml
@@ -2,7 +2,7 @@ name: Run Spotify Tracks Script
 
 on:
     schedule:
-        - cron: "0 */24 * * *" # Runs every 12 hours
+        - cron: "0 */24 * * *" # Runs daily at 00:00 UTC
     workflow_dispatch: # Allows manual triggering
 
 # Add concurrency control

--- a/.github/workflows/new-hugo-deploy.yaml
+++ b/.github/workflows/new-hugo-deploy.yaml
@@ -37,7 +37,7 @@ jobs:
             resource-cache-key: ${{ env.HUGO_RESOURCES_KEY }}
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
               with:
                   fetch-depth: 1
 
@@ -52,14 +52,14 @@ jobs:
                   echo "Directory structure created successfully"
 
             - name: Setup Hugo
-              uses: peaceiris/actions-hugo@v3
+              uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
               with:
                   hugo-version: ${{ env.HUGO_VERSION }}
                   extended: true
 
             - name: Restore Hugo Build Cache
               id: hugo-cache
-              uses: actions/cache@v3
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 (v3 backend was shut down)
               with:
                   path: |
                       /tmp/hugo_cache
@@ -73,7 +73,7 @@ jobs:
             # Separate long-term resource cache
             - name: Restore Hugo Resources Cache
               id: hugo-resources-cache
-              uses: actions/cache@v3
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 (v3 backend was shut down)
               with:
                   path: /tmp/hugo_resources
                   key: ${{ env.HUGO_RESOURCES_KEY }}
@@ -87,7 +87,7 @@ jobs:
         timeout-minutes: 30
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
               with:
                   fetch-depth: 1
 
@@ -102,13 +102,13 @@ jobs:
                   done
 
             - name: Setup Hugo
-              uses: peaceiris/actions-hugo@v3
+              uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
               with:
                   hugo-version: ${{ env.HUGO_VERSION }}
                   extended: true
 
             - name: Restore Hugo Build Cache
-              uses: actions/cache@v3
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 (v3 backend was shut down)
               with:
                   path: |
                       /tmp/hugo_cache
@@ -117,7 +117,7 @@ jobs:
                   key: ${{ needs.setup.outputs.cache-key }}-hugo
 
             - name: Restore Hugo Resources Cache
-              uses: actions/cache@v3
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 (v3 backend was shut down)
               with:
                   path: /tmp/hugo_resources
                   key: ${{ needs.setup.outputs.resource-cache-key }}
@@ -175,7 +175,7 @@ jobs:
                   HUGO_RESOURCECACHE: ${HUGO_RESOURCECACHE}
 
             - name: Upload Build Artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 (v3 was shut down Jan 2025)
               with:
                   name: hugo-build
                   path: public/
@@ -189,12 +189,12 @@ jobs:
         environment: production
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
               with:
                   fetch-depth: 1
 
             - name: Download Build Artifact
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 (v3 was shut down Jan 2025)
               with:
                   name: hugo-build
                   path: public/
@@ -213,7 +213,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Delete Build Artifact
-              uses: geekyeggo/delete-artifact@v2
+              uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0 (v2 predates the current artifact API)
               with:
                   name: hugo-build
                   failOnError: false

--- a/.github/workflows/notes.yaml
+++ b/.github/workflows/notes.yaml
@@ -5,6 +5,12 @@ on:
         - cron: "*/10 * * * *" # Runs every 10 minutes
     workflow_dispatch: # Allows manual triggering
 
+# Add concurrency control (a run that outlives the 10-minute cadence would
+# otherwise overlap the next one and race on the registry push)
+concurrency:
+    group: micro-posts-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     update-micro-posts:
         runs-on: ubuntu-latest

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -1,13 +1,13 @@
 baseURL = "https://harper.blog/"
 publishDir = "public"
-locale = "en-us"
 title = "Harper Reed's Blog"
+# Absolutizes URLs in rendered HTML only (feeds are unaffected). Dropping it
+# would churn every built page for no visible gain, so it stays.
 canonifyURLs = true
 enableRobotsTXT = true
 enableGitInfo = true
 timeout = "300s"                 # Increased for large image processing
 defaultContentLanguage = "en"
-author = "Harper Reed"
 disableKinds = []
 timeZone = "America/Chicago"
 

--- a/config/_default/imaging.toml
+++ b/config/_default/imaging.toml
@@ -1,16 +1,19 @@
 # ABOUTME: Hugo image processing configuration for automatic resizing and WebP conversion.
 # ABOUTME: Sets quality defaults and EXIF handling for processed images.
 
-# Default quality for resized images (0-100)
-quality = 82
-
 # Background color for images with transparency (when converting to non-alpha formats)
 bgColor = "#ffffff"
 
 # Resampling filter for resizing (box is fast, lanczos is higher quality)
 resampleFilter = "lanczos"
 
-# Hint for the image encoder (photo, picture, drawing, icon, text)
+# Quality for resized images (0-100); Hugo 0.163+ takes it per format
+[jpeg]
+quality = 82
+
+[webp]
+quality = 82
+# Hint for the webp encoder (photo, picture, drawing, icon, text)
 hint = "photo"
 
 [exif]

--- a/gotchas.md
+++ b/gotchas.md
@@ -24,6 +24,7 @@ Hard-won facts about working on harper.blog. Add yours; keep entries short.
 
 - `RegularPages` sorts by weight before date: `/about/` (menu weight 3, dateless, `nofeed: true`) is `RegularPages[0]` on every language site. Anything taking "the newest page" must filter nofeed/dateless pages first — this zeroed the root feed's `lastBuildDate` and silently wasted a feed slot.
 - `.Paginate` may only get one collection+size per page, but repeat calls return the first paginator — so head partials (which render before the main block) and list templates share `partials/paginator.html` as the single place that defines collections and sizes. Never call `.Paginator`/`.Paginate` anywhere else.
+- `canonifyURLs = true` only absolutizes URLs in rendered HTML output — `.Content` embedded in RSS templates keeps root-relative img srcs. Feed templates that need absolute srcs must prefix `site.BaseURL` themselves (`index.rss.xml` does); prefixing `.Permalink` onto an already-root-relative src mangles the path.
 
 ## Theme CSS
 

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -125,7 +125,9 @@
                 <description>
                     {{ printf "<![CDATA[" | safeHTML }}
                         {{- $content := replaceRE "a href=\"(#.*?)\"" (printf "%s%s%s" "a href=\"" .Permalink "$1\"") .Content -}}
-                        {{- $content = replaceRE "img src=\"(.*?)\"" (printf "%s%s%s" "img src=\"" .Permalink "$1\"") $content -}}
+                        {{- /* Render hooks resolve content images to root-relative or absolute URLs, so only
+                               root-relative srcs need the host; prefixing .Permalink onto them mangles the path */ -}}
+                        {{- $content = replaceRE "img src=\"(/[^\"]*)\"" (printf "img src=\"%s$1\"" (strings.TrimSuffix "/" site.BaseURL)) $content -}}
                         {{ $content | safeHTML }}
                         
                         {{- $images := union (.Resources.ByType "image") (.Resources.Match "**.{jpg,jpeg,png,gif,webp}") -}}


### PR DESCRIPTION
Third audit tranche (I23, M1, plus a latent feed bug found while verifying). Most of the rest of this tranche's list turned out to be already fixed in earlier PRs — receipts at the bottom.

## CI (I23)
- SHA-pin the remaining tag-pinned actions: `authors.yml` (checkout, create-pull-request), `check-i18n.yaml` (checkout, setup-uv), `new-hugo-deploy.yaml` (everything).
- `new-hugo-deploy.yaml` also sat on `upload/download-artifact@v3` and `cache@v3`, which GitHub shut down in 2025 — bumped to current majors. Note this workflow is `workflow_dispatch`-only and dormant (Netlify does real deploys), so the bumps are untestable without triggering a prod deploy; happy to just delete the workflow instead if you'd rather.
- `notes.yaml` gets the per-workflow concurrency group its sibling crons got in #167; two cron comments now state the real schedule.
- The four content crons were already pinned + `git add`-scoped in #167 — untouched here, all green.

## Config (M1)
- `imaging.quality`/`imaging.hint` → per-format `[jpeg]`/`[webp]` keys (deprecated in Hugo 0.163; the build warned twice on every run — now zero warnings). `bgColor`/`resampleFilter` are *not* deprecated; the audit overstated that.
- Dropped dead root keys `locale` and `author` from hugo.toml (languages.toml owns locales, params.toml owns `[author]`; the only `site.Author` reference is a never-taken fallback branch in the vendored rss.xml copy).
- `canonifyURLs` **stays**, with an honest comment: build evidence shows it only absolutizes HTML output, feeds were never depending on it, and dropping it churns every built page for no visible gain.

## Home feed img srcs (found during verification)
`index.rss.xml` prefixed `.Permalink` onto **every** `img src` in embedded content. Render hooks resolve content images to root-relative paths (`/images/...`, `/2026/...`), so the first post with an inline image to enter the home feed would have gotten `https://harper.blog/<post>//images/...` — a 404. Now only root-relative srcs get prefixed, with the bare host. Verified: home feeds (en/ja/es) emit only absolute srcs; section feeds use the other template and are untouched.

## Verified
- `/tmp` build: exit 0, **0 warnings** (was 4), no mangled or relative srcs in home feeds, og:locale + RSS `<language>` intact per language.
- `actionlint`: no new findings (pre-existing shellcheck style notes remain; also flagging: `new-hugo-deploy.yaml:34` references a `deps-cache` step that doesn't exist — pre-existing, dormant workflow).
- `make check-i18n` green.

## Already done, verified closed
- I12/I13/I14 (twitter:site, og:video scoping, og:locale, og:image dims, featured-image fallback) — landed in #168's `b01bc6f49`.
- I24 (`.spotify_cache` in .gitignore) and cron `git add -A` removal — #167's `5bf105e29`.
- I27 (`loading="lazy"` on Spotify iframes) — already on both variants.
- I20 (ja/zh dead homepage links) — resolved by #170's `/media/links` fix; all five link targets verified present in the build.
- M7 — wlwmanifest/EditURI links already gone; `<meta charset>` sits at byte ~135, well inside the first 1024.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected RSS image links so embedded images resolve properly to absolute URLs.
  - Prevented malformed links for already root-relative image paths.

- **Configuration**
  - Improved image quality settings for JPEG and WebP formats.
  - Clarified site URL and canonicalization settings.

- **Maintenance**
  - Improved workflow reliability by preventing duplicate runs.
  - Pinned automation actions for more consistent execution.
  - Reduced scheduled Goodreads and Spotify imports to once daily; manual runs remain available.

- **Documentation**
  - Added guidance about RSS image URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->