### PR TITLE
fix(css): text-wrap corrections — headings pretty, prose default

### DIFF
--- a/assets/css/harper.css
+++ b/assets/css/harper.css
@@ -34,7 +34,8 @@ h3,
 h4,
 h5,
 h6 {
-    text-wrap: balance;
+    /* pretty avoids orphan words without balance's early wrap on long titles */
+    text-wrap: pretty;
 }
 
 p {

--- a/assets/css/harper.css
+++ b/assets/css/harper.css
@@ -38,9 +38,8 @@ h6 {
     text-wrap: pretty;
 }
 
-p {
-    text-wrap: pretty;
-}
+/* Paragraphs use the default greedy wrap: Safari's text-wrap pretty
+   rag-balances whole paragraphs, leaving lines well short of the column */
 
 article p {
     margin-block: 0 1.25em;

--- a/gotchas.md
+++ b/gotchas.md
@@ -19,6 +19,7 @@ Hard-won facts about working on harper.blog. Add yours; keep entries short.
 - Any visual change is provisional until Harper has seen it rendered on the preview — approval of a written list is not visual sign-off.
 - Markdown `![]()` images in posts stay bare. The figure/image shortcodes are the deliberate opt-in for the framed breakout treatment — an auto-wrapping render hook was tried and reverted. Don't blanket-normalize how content renders.
 - PR #156 (Tailwind redesign) was closed unmerged. Notes referencing Tailwind/PurgeCSS/postcss describe that dead branch, not main.
+- Headings wrap `pretty`, not `balance` — balance's even-line break read as a phantom width limit on long titles (looked capped well short of the 720px column). Harper confirmed pretty on preview, 2026-08-16.
 
 ## Templates
 

--- a/gotchas.md
+++ b/gotchas.md
@@ -20,6 +20,7 @@ Hard-won facts about working on harper.blog. Add yours; keep entries short.
 - Markdown `![]()` images in posts stay bare. The figure/image shortcodes are the deliberate opt-in for the framed breakout treatment — an auto-wrapping render hook was tried and reverted. Don't blanket-normalize how content renders.
 - PR #156 (Tailwind redesign) was closed unmerged. Notes referencing Tailwind/PurgeCSS/postcss describe that dead branch, not main.
 - Headings wrap `pretty`, not `balance` — balance's even-line break read as a phantom width limit on long titles (looked capped well short of the 720px column). Harper confirmed pretty on preview, 2026-08-16.
+- Paragraphs get NO `text-wrap` rule (default greedy wrap). `p { text-wrap: pretty }` shipped in #161 and read fine then, but Safari's pretty now rag-balances whole paragraphs — lines stop short of the column edge, same phantom-width look. Harper confirmed the removal on preview, 2026-08-16.
 
 ## Templates
 


### PR DESCRIPTION
Two text-wrap fixes, both eyeballed and approved by Harper on the tailscale preview:

1. **Headings: `balance` → `pretty`.** Balance breaks long titles into even half-width lines, which reads as a phantom width limit next to the 1000px figure breakout. Pretty keeps the orphan-word protection but lets titles fill the 720px column.

2. **Paragraphs: drop `text-wrap: pretty` entirely.** Safari's pretty implementation now rag-balances whole paragraphs — prose lines stop well short of the column edge, the same phantom-width look. This un-ships a piece of #161's text-wrap polish deliberately: browsers changed underneath it. Default greedy wrap fills the measure.

gotchas.md records both as settled decisions.