### PR TITLE
feat(media): hub band + cover/art thumbnails on the media lists

### DIFF
--- a/assets/css/media.css
+++ b/assets/css/media.css
@@ -1,18 +1,5 @@
-/* ABOUTME: Media section lists (/media/ and books/music/links): date-grouped rows with type markers. */
-/* ABOUTME: Markup comes from layouts/partials/media-list.html; grid pages style themselves in books.css/music.css. */
-
-/* The "/ ''" alt text keeps screen readers from announcing the emoji */
-.media-book::before {
-    content: "📚 " / "";
-}
-
-.media-music::before {
-    content: "🎵 " / "";
-}
-
-.media-link::before {
-    content: "🔗 " / "";
-}
+/* ABOUTME: Media section lists (/media/ and books/music/links): date-grouped rows with cover/art thumbs, plus the /media/ hub band. */
+/* ABOUTME: Markup comes from layouts/partials/media-list.html and layouts/media/list.html; grid pages style themselves in books.css/music.css. */
 
 .media-posts {
     list-style: none;
@@ -22,7 +9,7 @@
 
 .media-posts li {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     margin-bottom: 0.7em;
 }
 
@@ -33,27 +20,145 @@
 }
 
 .media-posts a {
+    display: flex;
+    align-items: center;
+    gap: 0.6em;
     text-decoration: none;
+}
+
+/* Cover/art thumbnail; the glyph variant stands in when a row has no image */
+.media-thumb {
+    flex: none;
+    width: 2.25rem;
+    height: 2.25rem;
+    object-fit: cover;
+    border: 1px solid var(--color-tertiary);
+    border-radius: var(--border-radius-sm);
+    background: var(--color-tertiary);
+}
+
+.media-thumb-glyph {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.05rem;
+}
+
+.media-text {
+    display: block;
 }
 
 .media-posts a .media-title {
     text-decoration: underline;
 }
 
-.media-posts .media-domain {
+.media-domain {
     color: var(--color-muted);
 }
 
-/* Muted item count in the grid pages' year/month headings */
+/* Muted item count in the grid pages' year/month headings and the hub headings */
 .group-count {
     font-size: 0.65em;
     font-weight: 400;
     color: var(--color-muted);
 }
 
+/* Hub band on /media/ page 1: latest read, recent tracks, recent links */
+.media-hub {
+    margin-block: 1.5em 2.5em;
+}
+
+.media-hub-block {
+    margin-block-end: 2em;
+}
+
+.media-hub-heading {
+    font-size: 1.15rem;
+    margin-block: 0 0.6em;
+}
+
+.media-hub-heading a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.media-hub-heading a:hover {
+    text-decoration: underline;
+}
+
+a.media-hub-book {
+    display: flex;
+    align-items: flex-start;
+    gap: 1em;
+    text-decoration: none;
+}
+
+/* books.css sets the 2/3 aspect and frame; only the size is ours */
+.media-hub-book .book-cover {
+    flex: none;
+    width: 96px;
+}
+
+.media-hub-book-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25em;
+}
+
+.media-hub-book .media-title {
+    text-decoration: underline;
+}
+
+.book-rating {
+    color: var(--color-primary);
+    letter-spacing: 0.1em;
+}
+
+.media-hub-tagline {
+    font-size: 0.9rem;
+    font-style: italic;
+    color: var(--color-muted);
+}
+
+.media-hub-tracks {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: var(--margin);
+}
+
+.media-hub-links {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.media-hub-links li {
+    margin-block-end: 0.9em;
+}
+
+.media-hub-links a {
+    text-decoration: none;
+}
+
+.media-hub-links .media-title {
+    text-decoration: underline;
+}
+
+.media-hub-summary {
+    margin: 0.15em 0 0;
+    font-size: 0.9rem;
+    color: var(--color-muted);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    line-clamp: 2;
+    overflow: hidden;
+}
+
 @media (max-width: 600px) {
     .media-posts li {
         flex-direction: column;
+        align-items: flex-start;
         margin-bottom: 1em;
     }
 
@@ -65,5 +170,13 @@
 
     .media-posts li > span:empty {
         display: none;
+    }
+
+    .media-hub-tracks {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    .media-hub-book .book-cover {
+        width: 80px;
     }
 }

--- a/gotchas.md
+++ b/gotchas.md
@@ -48,6 +48,7 @@ Hard-won facts about working on harper.blog. Add yours; keep entries short.
 - Registry writes in `grab_micro_posts_fixed.py` are atomic (temp + `os.replace`). `save_url_registry` and `save_content_registry` leave temp files prefixed with the registry filename if interrupted; safe to delete.
 - CI workflow caches `./tools/.script_cache` (dot-prefixed). Code must use `CACHE_DIRECTORY = ".script_cache"` — no dot was the old mismatch that meant every OpenAI call was a cache miss.
 - `grab_micro_posts_fixed.main()`, `grab_starred_links.main()`, `grab_spotify_saved_tracks.main()`, and `grab_read_books.main()` all return `int` and call `sys.exit(main())`. Per-item failures log and continue; run-level failures (auth, feed unreachable, all items failed) exit non-zero so GitHub Actions goes red.
+- `grab_read_books.py` skips any book whose `index.md` exists — content unchecked. A zero-byte `index.md` (automation race mid-write) permanently blocks that book from re-fetching; delete the empty bundle dir and the daily run recreates it.
 - `markup.toml` sets goldmark `unsafe = true` (old posts need raw HTML). Feed-ingestion tools must sanitize all feed-derived content that lands in markdown bodies — use `html.escape()` for text and `frontmatter.Post(content, **metadata)` (never `frontmatter.loads(feed_body)`) to prevent frontmatter injection.
 
 ## Content

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -185,6 +185,19 @@
 - id: songs-count
   translation: "%d songs"
 
+- id: links-count
+  translation: "%d links"
+
+# Media hub (/media/ page 1)
+- id: latest-read
+  translation: "Latest read"
+
+- id: recent-tracks
+  translation: "Recent tracks"
+
+- id: recent-links
+  translation: "Recent links"
+
 # Reading stats shortcode
 - id: reading-stats-books
   translation:

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -185,6 +185,19 @@
 - id: songs-count
   translation: "%d canciones"
 
+- id: links-count
+  translation: "%d enlaces"
+
+# Media hub (/media/ page 1)
+- id: latest-read
+  translation: "Última lectura"
+
+- id: recent-tracks
+  translation: "Canciones recientes"
+
+- id: recent-links
+  translation: "Enlaces recientes"
+
 # Reading stats shortcode
 - id: reading-stats-books
   translation:

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -177,6 +177,19 @@
 - id: songs-count
   translation: "%d曲"
 
+- id: links-count
+  translation: "%d件のリンク"
+
+# Media hub (/media/ page 1)
+- id: latest-read
+  translation: "最近読んだ本"
+
+- id: recent-tracks
+  translation: "最近聴いた曲"
+
+- id: recent-links
+  translation: "最近のリンク"
+
 - id: home-aria
   translation: "ホーム"
 

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -185,6 +185,19 @@
 - id: songs-count
   translation: "%d곡"
 
+- id: links-count
+  translation: "링크 %d개"
+
+# Media hub (/media/ page 1)
+- id: latest-read
+  translation: "최근 읽은 책"
+
+- id: recent-tracks
+  translation: "최근 들은 곡"
+
+- id: recent-links
+  translation: "최근 링크"
+
 # Additional accessibility
 - id: home-aria
   translation: "홈"

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -185,6 +185,19 @@
 - id: songs-count
   translation: "%d首"
 
+- id: links-count
+  translation: "%d个链接"
+
+# Media hub (/media/ page 1)
+- id: latest-read
+  translation: "最近读的书"
+
+- id: recent-tracks
+  translation: "最近听的歌"
+
+- id: recent-links
+  translation: "最近的链接"
+
 # Additional accessibility
 - id: home-aria
   translation: "首页"

--- a/layouts/media/list.html
+++ b/layouts/media/list.html
@@ -1,11 +1,86 @@
 {{- /* ABOUTME: /media/ firehose — books, music, and links merged into one date-sorted stream. */}}
-{{- /* ABOUTME: Row rendering lives in partials/media-list.html, shared with each section's own list. */}}
+{{- /* ABOUTME: Page 1 opens with a hub band (latest read, recent tracks/links); rows render via partials/media-list.html. */}}
 {{ define "main" }}
 <article>
     <h1 class="sr-only">{{ .Title }}</h1>
     {{ .Content }}
     {{/* Collection and page size live in partials/paginator.html, shared with head/seo-canonical.html */}}
     {{ $paginator := partial "paginator.html" . }}
+    {{- if eq $paginator.PageNumber 1 }}
+    {{- /* Media content lives on the default (en) site only; translated pages must reach across */}}
+    {{- $all := where hugo.Sites.Default.RegularPages "Params.nofeed" "ne" true }}
+    {{- $books := (where $all "Section" "books").ByDate.Reverse }}
+    {{- $music := (where $all "Section" "music").ByDate.Reverse }}
+    {{- $links := (where $all "Section" "links").ByDate.Reverse }}
+    <div class="media-hub">
+        <section class="media-hub-block">
+            <h2 class="media-hub-heading">
+                <a href="{{ with .Site.GetPage "/books" }}{{ .RelPermalink }}{{ end }}"><span aria-hidden="true">📚 </span>{{ i18n "latest-read" }} <span class="group-count">· {{ printf (i18n "books-count") (len $books) }}</span></a>
+            </h2>
+            {{- with $books }}
+            {{- with index . 0 }}
+            <a href="{{ .RelPermalink }}" class="media-hub-book">
+                {{- with .Params.asin }}
+                <img src="https://images-na.ssl-images-amazon.com/images/P/{{ . }}.01._SCLZZZZZZZ.jpg" class="book-cover" alt="" decoding="async">
+                {{- else }}
+                <span class="book-cover book-cover-fallback" aria-hidden="true">📖</span>
+                {{- end }}
+                <span class="media-hub-book-meta">
+                    <span class="media-title">{{ .Title }}</span>
+                    {{- with or .Params.book_author .Params.author }}
+                    <span class="book-author">{{ printf (i18n "by-author") . }}</span>
+                    {{- end }}
+                    {{- $rating := int (default "0" .Params.review_rating) }}
+                    {{- if and (gt $rating 0) (le $rating 5) }}
+                    <span class="book-rating" role="img" aria-label="{{ $rating }}/5">{{ strings.Repeat $rating "★" }}{{ strings.Repeat (sub 5 $rating) "☆" }}</span>
+                    {{- end }}
+                    {{- with .Params.tagline }}
+                    <span class="media-hub-tagline">{{ . }}</span>
+                    {{- end }}
+                </span>
+            </a>
+            {{- end }}
+            {{- end }}
+        </section>
+        <section class="media-hub-block">
+            <h2 class="media-hub-heading">
+                <a href="{{ with .Site.GetPage "/music" }}{{ .RelPermalink }}{{ end }}"><span aria-hidden="true">🎵 </span>{{ i18n "recent-tracks" }} <span class="group-count">· {{ printf (i18n "songs-count") (len $music) }}</span></a>
+            </h2>
+            <div class="media-hub-tracks">
+                {{- range first 6 $music }}
+                <a href="{{ .RelPermalink }}" aria-label="{{ .Title }}{{ with .Params.artist }} — {{ . }}{{ end }}" title="{{ .Title }}{{ with .Params.artist }} — {{ . }}{{ end }}">
+                    {{- /* Spotify serves the same art at 300px under the 1e02 prefix; unknown URLs pass through full-size */}}
+                    {{- with .Params.album_image }}
+                    <img src="{{ replace . "ab67616d0000b273" "ab67616d00001e02" }}" class="album-art" alt="" loading="lazy" decoding="async">
+                    {{- else }}
+                    <span class="album-art album-art-fallback" aria-hidden="true">🎵</span>
+                    {{- end }}
+                </a>
+                {{- end }}
+            </div>
+        </section>
+        <section class="media-hub-block">
+            <h2 class="media-hub-heading">
+                <a href="{{ with .Site.GetPage "/links" }}{{ .RelPermalink }}{{ end }}"><span aria-hidden="true">🔗 </span>{{ i18n "recent-links" }} <span class="group-count">· {{ printf (i18n "links-count") (len $links) }}</span></a>
+            </h2>
+            <ul class="media-hub-links">
+                {{- range first 3 $links }}
+                {{- $link := . }}
+                <li>
+                    <a href="{{ or .Params.original_url .RelPermalink }}"
+                        {{- with .Params.original_url }} target="_blank" rel="noopener noreferrer" data-tinylytics-event="outbound.link" data-tinylytics-event-value="{{ $link.Title }}"{{ end }}>
+                        <span class="media-title">{{ .Title }}</span>
+                        {{- with .Params.original_url }} <span class="media-domain">({{ (urls.Parse .).Hostname }})</span>{{ end }}
+                    </a>
+                    {{- with .Params.summary }}
+                    <p class="media-hub-summary">{{ . }}</p>
+                    {{- end }}
+                </li>
+                {{- end }}
+            </ul>
+        </section>
+    </div>
+    {{- end }}
     {{ partial "media-list.html" $paginator.Pages }}
     {{ partial "pagination.html" . }}
 </article>

--- a/layouts/partials/media-list.html
+++ b/layouts/partials/media-list.html
@@ -13,8 +13,11 @@
         {{- $event := "" }}
         {{- $context := "" }}
         {{- $class := "" }}
+        {{- $thumb := "" }}
+        {{- $glyph := "" }}
         {{- if eq .Section "links" }}
             {{- $class = "media-link" }}
+            {{- $glyph = "🔗" }}
             {{- with .Params.original_url }}
                 {{- $href = . }}
                 {{- $event = "outbound.link" }}
@@ -22,23 +25,35 @@
             {{- end }}
         {{- else if eq .Section "music" }}
             {{- $class = "media-music" }}
+            {{- $glyph = "🎵" }}
             {{- with .Params.artist }}{{ $context = printf (i18n "by-artist") . }}{{ end }}
             {{- with .Params.spotify_url }}
                 {{- $href = . }}
                 {{- $event = "outbound.spotify" }}
             {{- end }}
+            {{- /* Spotify serves the same art at 64px under the 4851 prefix; unknown URLs pass through full-size */}}
+            {{- with .Params.album_image }}{{ $thumb = replace . "ab67616d0000b273" "ab67616d00004851" }}{{ end }}
         {{- else if eq .Section "books" }}
             {{- $class = "media-book" }}
+            {{- $glyph = "📚" }}
             {{- with or .Params.book_author .Params.author }}{{ $context = printf (i18n "by-author") . }}{{ end }}
             {{- with .Params.asin }}
                 {{- $href = printf "https://www.amazon.com/dp/%s?tag=%s" (urlquery .) (urlquery site.Params.amazon_tag) }}
                 {{- $event = "outbound.amazon" }}
+                {{- $thumb = printf "https://images-na.ssl-images-amazon.com/images/P/%s.01._SL160_.jpg" . }}
             {{- end }}
         {{- end }}
         <a href="{{ $href }}" class="{{ $class }}"
             {{- if $event }} target="_blank" rel="noopener noreferrer" data-tinylytics-event="{{ $event }}" data-tinylytics-event-value="{{ .Title }}"{{ end }}>
-            <span class="media-title">{{ .Title }}</span>
-            {{- with $context }} <span class="media-domain">({{ . }})</span>{{ end }}
+            {{- with $thumb }}
+            <img src="{{ . }}" class="media-thumb" alt="" loading="lazy" decoding="async">
+            {{- else }}
+            <span class="media-thumb media-thumb-glyph" aria-hidden="true">{{ $glyph }}</span>
+            {{- end }}
+            <span class="media-text">
+                <span class="media-title">{{ .Title }}</span>
+                {{- with $context }} <span class="media-domain">({{ . }})</span>{{ end }}
+            </span>
         </a>
     </li>
     {{- end }}


### PR DESCRIPTION
## What

**/media page 1 opens with a hub band** (template-only; pager pages 2+ stay pure firehose):
- 📚 **Latest read** — cover, title, author, your star rating, tagline
- 🎵 **Recent tracks** — six album-art tiles
- 🔗 **Recent links** — three titles with domain + two-line summary
- Each heading links to its section and carries the total count (851 books · 1216 songs · 500 links), reusing the grids' `group-count` idiom

**Every row in the shared media list gets a thumbnail** (applies to /media, /media/books, /media/music, /media/links): Amazon cover by ASIN (`_SL160_`, ~4.5KB), Spotify album art via the 64px URL-prefix swap (~4KB), emoji chip fallback when no image exists. The emoji `::before` type markers retire — the art is the type marker now.

Both smaller image variants were verified live with curl before use (200s, real bytes). All colors via CSS vars; no inline styles; new i18n keys added to all five languages (`make check-i18n` green).

## Bonus fix

`content/books/2026-08-15-infinite-archive-the-midsolar-murders-3/index.md` was a **zero-byte file** committed by an automation race (e94538335, a spotify auto-commit swept it mid-write — the exact cross-workflow race #172's concurrency guards address). The grabber skips any book whose index.md exists, so the empty file permanently blocked the real entry. Deleted the empty bundle; the daily goodreads run recreates it with full frontmatter.

## Verification

- `/tmp` build: zero warnings; hub renders on en + es page 1 only, absent from pager pages
- Row thumbs: 20/20 on /media/books; Spotify 64px swap confirmed in output
- `make check-i18n`: 14 tests + checker pass
- Visual is provisional until Doctor Biz eyeballs the preview: https://disaster.porpoise-alkaline.ts.net/media/

Independent of #172 and #173. gotchas.md edit lands in a third distinct section — merges cleanly with both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a media hub featuring the latest read book, recent tracks, and recent links.
  - Added media counts, metadata, ratings, summaries, artwork, domains, and external-link indicators.
  - Added thumbnail images with accessible fallback icons for books, tracks, and links.
  - Added responsive layouts for media hub content, including improved mobile track and book displays.

- **Localization**
  - Added translated media hub labels and link counts in English, Spanish, Japanese, Korean, and Chinese.

- **Documentation**
  - Documented a book-fetching edge case involving existing empty index files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->