### PR TITLE
feat(media): separator between hub and the log

### DIFF
--- a/assets/css/media.css
+++ b/assets/css/media.css
@@ -86,6 +86,15 @@
     text-decoration: underline;
 }
 
+/* Boundary between the hub band and the log — hub sections and log rows
+   otherwise read as one continuous list. */
+.media-log-heading {
+    font-size: 1.15rem;
+    margin-block: 0 0.6em;
+    padding-block-start: 1.25em;
+    border-block-start: 2px solid var(--color-tertiary);
+}
+
 a.media-hub-book {
     display: flex;
     align-items: flex-start;

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -198,6 +198,9 @@
 - id: recent-links
   translation: "Recent links"
 
+- id: media-log
+  translation: "The log"
+
 # Reading stats shortcode
 - id: reading-stats-books
   translation:

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -198,6 +198,9 @@
 - id: recent-links
   translation: "Enlaces recientes"
 
+- id: media-log
+  translation: "Bitácora"
+
 # Reading stats shortcode
 - id: reading-stats-books
   translation:

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -190,6 +190,9 @@
 - id: recent-links
   translation: "最近のリンク"
 
+- id: media-log
+  translation: "ログ"
+
 - id: home-aria
   translation: "ホーム"
 

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -198,6 +198,9 @@
 - id: recent-links
   translation: "최근 링크"
 
+- id: media-log
+  translation: "기록"
+
 # Additional accessibility
 - id: home-aria
   translation: "홈"

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -198,6 +198,9 @@
 - id: recent-links
   translation: "最近的链接"
 
+- id: media-log
+  translation: "记录"
+
 # Additional accessibility
 - id: home-aria
   translation: "首页"

--- a/layouts/media/list.html
+++ b/layouts/media/list.html
@@ -80,6 +80,7 @@
             </ul>
         </section>
     </div>
+    <h2 class="media-log-heading"><span aria-hidden="true">🗓️ </span>{{ i18n "media-log" }}</h2>
     {{- end }}
     {{ partial "media-list.html" $paginator.Pages }}
     {{ partial "pagination.html" . }}


### PR DESCRIPTION
The /media/ hub's Recent links section blended straight into the date-grouped log. Adds a "🗓️ The log" heading between them — same typography as the hub headings, sitting on the site's standard 2px `--color-tertiary` rule, so the log reads as its own section.

- Page 1 only (pages 2+ have no hub, so no separator needed) — verified in build output
- New i18n key `media-log` in all five languages (en "The log", es "Bitácora", ja "ログ", ko "기록", zh "记录"); `make check-i18n` clean
- No inline styles (CSP), no hardcoded colors — rule is in the media.css bundle

Visual change: awaiting Harper's eyeball on the preview before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a localized “The Log” heading with a calendar icon to the first page of the media listing.
  - Improved visual separation between the media hub and media log for easier navigation.

- **Localization**
  - Added translations for the new heading in English, Spanish, Japanese, Korean, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->