### PR TITLE
fix(redirects): 301 old en section lists, grids, and feeds to /media/

### DIFF
--- a/gotchas.md
+++ b/gotchas.md
@@ -45,6 +45,7 @@ Hard-won facts about working on harper.blog. Add yours; keep entries short.
 - `site.RegularPages` is language-scoped: on an /es/ page it returns only Spanish pages. Books/music/links exist only on the en site (translations are `_index.<lang>.md` suffix files), so filtering it by those sections comes back empty there and lists/stats render blank. For cross-language data use `hugo.Sites.Default.RegularPages` — and it's `hugo.Sites`, not `site.Sites` (deprecated since hugo 0.156, WARNs in the server log).
 - `i18n` placeholders: a key called as `{{ i18n "key" arg }}` must use `{{ . }}` in its value; `%s`/`%d` values only work via `printf (i18n "key") args`. Mixing the styles renders blanks or `%!(EXTRA …)` garbage. `make check-i18n` catches parity/phantom/dead keys — run it after touching `layouts/` or `i18n/`.
 - Frontmatter `aliases:` on section `_index.*.md` pages with a `url:` override never emitted redirect stubs (dev server, full rebuilds included). URL moves go in `static/_redirects` (Netlify) instead — the `/id/*` and `/es/media/*/list/` entries are the pattern.
+- A section URL move breaks a whole family, not one page: list, grid, feed (`index.xml`), and pagination each need a redirect, and individual pages may stay at the old path (so no broad splats). The media consolidation shipped with only the es redirects; the en 404s — including feed subscribers — went unnoticed for a day. Review a URL move by curling the old URLs.
 
 ## Python tools
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -5,3 +5,18 @@
 # Spanish media sections moved to the English URL scheme 2026-08 (was media/*/list).
 /es/media/books/list/* /es/media/books/:splat 301
 /es/media/music/list/* /es/media/music/:splat 301
+
+# Media consolidation 2026-08: the books/music/links lists, grids, feeds, and
+# pagination moved under /media/. Individual pages kept their old URLs, so
+# exact paths only — a /books/* splat would shadow /books/<slug>/.
+/books/ /media/books/ 301
+/music/ /media/music/ 301
+/links/ /media/links/ 301
+/books/grid/ /media/books/grid/ 301
+/music/grid/ /media/music/grid/ 301
+/books/index.xml /media/books/index.xml 301
+/music/index.xml /media/music/index.xml 301
+/links/index.xml /media/links/index.xml 301
+/books/page/* /media/books/page/:splat 301
+/music/page/* /media/music/page/:splat 301
+/links/page/* /media/links/page/:splat 301


### PR DESCRIPTION
## What

The media consolidation (#174) moved the English books/music/links lists, grids, feeds, and pagination under `/media/` but only added redirects for the old Spanish scheme. The old English URLs have been 404ing since — including `/books/index.xml` and `/music/index.xml`, so anyone subscribed to those feeds went dark.

This adds the missing 301s to `static/_redirects`, plus a gotchas entry so the next URL move gets reviewed by curling the old URLs.

## Why exact paths, not splats

Individual pages did **not** move — `/books/<slug>/` and `/music/<slug>/` are still live at their old paths, so a broad `/books/*` splat would shadow every one of them. The only splats are `/*/page/*` (safe: content slugs are date-prefixed, nothing real lives under `/books/page/`).

No `/links/grid/` entry: links never had a grid (`/media/links/grid/` 404s too).

## Verified

Every redirect target returns 200 on production:
- `/media/{books,music,links}/` ✅
- `/media/{books,music}/grid/` ✅
- `/media/{books,music,links}/index.xml` ✅
- `/media/{books,music,links}/page/2/` ✅

Netlify's "Redirect rules" deploy check validates the syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added redirects for consolidated media list, grid, feed, and pagination URLs across supported languages.
  - Existing individual media page URLs remain unchanged.

- **Documentation**
  - Documented multilingual redirect requirements and guidance for validating legacy URLs.
  - Clarified that broad wildcard redirects should be avoided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->