### PR TITLE
feat: verification infrastructure — make check, build gates, ruff (robustness phase 5/5)

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -57,10 +57,13 @@ jobs:
 
             - name: Install Hugo
               run: |
-                  curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_checksums.txt" -o /tmp/hugo_checksums.txt
-                  curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" -o /tmp/hugo.tar.gz
-                  grep "hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" /tmp/hugo_checksums.txt | sha256sum -c
-                  tar -xzf /tmp/hugo.tar.gz -C /usr/local/bin hugo
+                  # sha256sum -c resolves the filename from the checksums line, so the
+                  # tarball must sit next to it under its canonical release name.
+                  cd /tmp
+                  curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_checksums.txt" -o hugo_checksums.txt
+                  curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" -o "hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
+                  grep " hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz$" hugo_checksums.txt | sha256sum -c
+                  tar -xzf "hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" -C /usr/local/bin hugo
 
             - name: Build site
               run: hugo --destination /tmp/hugo-check --quiet -e production --logLevel warn

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -1,0 +1,78 @@
+name: Build check
+
+# Full build gate: hugo build, feed/redirect/inline-style checks, contrast sweep.
+# Runs on PRs and main-branch pushes that touch layout, config, or asset paths.
+on:
+    pull_request:
+        paths:
+            - "layouts/**"
+            - "config/**"
+            - "assets/**"
+            - "static/**"
+            - "i18n/**"
+            - "go.mod"
+            - "go.sum"
+            - "netlify.toml"
+            - "tools/check_feeds.py"
+            - "tools/check_redirects.py"
+            - "tools/check_inline_styles.py"
+            - ".github/workflows/build-check.yaml"
+    push:
+        branches:
+            - main
+        paths:
+            - "layouts/**"
+            - "config/**"
+            - "assets/**"
+            - "static/**"
+            - "i18n/**"
+            - "go.mod"
+            - "go.sum"
+            - "netlify.toml"
+            - "tools/check_feeds.py"
+            - "tools/check_redirects.py"
+            - "tools/check_inline_styles.py"
+            - ".github/workflows/build-check.yaml"
+
+permissions:
+    contents: read
+
+env:
+    HUGO_VERSION: "0.164.0"
+
+jobs:
+    build-check:
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        steps:
+            - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+              with:
+                  fetch-depth: 1
+
+            - name: Setup uv
+              uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+              with:
+                  enable-cache: true
+                  cache-dependency-glob: "tools/uv.lock"
+
+            - name: Install Hugo
+              run: |
+                  curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_checksums.txt" -o /tmp/hugo_checksums.txt
+                  curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" -o /tmp/hugo.tar.gz
+                  grep "hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" /tmp/hugo_checksums.txt | sha256sum -c
+                  tar -xzf /tmp/hugo.tar.gz -C /usr/local/bin hugo
+
+            - name: Build site
+              run: hugo --destination /tmp/hugo-check --quiet -e production --logLevel warn
+
+            - name: Check feeds
+              run: cd tools && uv run check_feeds.py /tmp/hugo-check
+
+            - name: Check redirects
+              run: cd tools && uv run check_redirects.py /tmp/hugo-check
+
+            - name: Check inline styles
+              run: cd tools && uv run check_inline_styles.py
+
+            - name: Check contrast
+              run: make check-contrast

--- a/.github/workflows/tools-tests.yaml
+++ b/.github/workflows/tools-tests.yaml
@@ -34,6 +34,10 @@ jobs:
                   enable-cache: true
                   cache-dependency-glob: "tools/uv.lock"
 
+            - name: Lint
+              working-directory: ./tools
+              run: uv run ruff check .
+
             - name: Run tools test suite
               working-directory: ./tools
               run: uv run pytest -q

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ check: tools-test check-i18n check-contrast
 
 # Run the Python tools test suite
 tools-test:
-	cd tools && uv run pytest -q
+	cd tools && uv run ruff check . && uv run pytest -q
 
 # Build the Hugo site
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+.PHONY: build serve getmodules check check-i18n check-contrast tools-test preview dev prod_build prod_build_verbose gitlog
+
+# Run every local verification: tools tests, i18n hygiene, contrast sweep
+check: tools-test check-i18n check-contrast
+
+# Run the Python tools test suite
+tools-test:
+	cd tools && uv run pytest -q
+
 # Build the Hugo site
 build:
 	hugo

--- a/assets/css/shortcodes.css
+++ b/assets/css/shortcodes.css
@@ -1,0 +1,13 @@
+/* ABOUTME: Styles for Hugo shortcodes, extracted from inline styles to satisfy production CSP. */
+/* ABOUTME: Production CSP has style-src 'self' — inline style= attributes are silently killed. */
+
+/* kitco embed shortcode: iframe sizing and centering */
+.kitco-embed {
+    display: block;
+    border: 0;
+    margin: 0 auto;
+    width: 100%;
+    height: 100vw;
+    max-width: 700px;
+    max-height: 700px;
+}

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -50,6 +50,7 @@ customcss = [
     "/css/photos.css",
     "/css/code.css",
     "/css/translations.css",
+    "/css/shortcodes.css",
     "syntax.css",
 ]
 

--- a/gotchas.md
+++ b/gotchas.md
@@ -8,7 +8,14 @@ Hard-won facts about working on harper.blog. Add yours; keep entries short.
 - Production deploys run `./scripts/build_with_random_theme.sh` — every deploy gets a random theme from `themes.css`. Visual changes must survive all themes, and the first deploy after a CSS change is worth a look.
 - Two hugo binaries exist: `.mise.toml` pins the real one; `/opt/homebrew/bin/hugo` drifts. If a build error names an API that greps clean, check `hugo version` first.
 - Never run a one-shot `hugo` build in the checkout while `hugo serve` is running — the server serves `public/` from disk, and the build poisons it and silently kills the watcher. Use `hugo --destination /tmp/hugo-verify` or stop the server. Recovery: kill server, `rm -rf public`, relaunch.
-- Build output is still slightly nondeterministic: photos RSS stamps `lastBuildDate` from `now`, and hugo silently drops GitInfo if git is locked mid-build. (Footer and out_of_date `partialCached` calls are now keyed properly.) Normalize before diffing two builds.
+- Build output can still differ across runs: hugo silently drops GitInfo if git is locked mid-build. (Photos RSS `lastBuildDate` now comes from the newest image note, and footer/out_of_date `partialCached` calls are keyed properly.) Normalize before diffing two builds.
+
+## CI workflows
+
+- `make check` is the canonical local gate: tools ruff+pytest, i18n parity, contrast sweep. CI mirrors it — tools-tests lints and tests `tools/`, check-i18n covers translations, and build-check does a pinned-hugo production build to /tmp plus feed/redirect/inline-style checkers on anything touching layouts/config/assets/static/i18n.
+- Cron content workflows push with a rebase-retry loop under a `concurrency` queue-of-one: a waiting run replaces the queued one, and a manual `workflow_dispatch` can be silently eaten by the next cron tick. If your dispatch vanished, that's why.
+- Job timeouts conclude `cancelled`, not `failure` — `if: failure()` alert steps stay silent on them, so a persistently hanging cron eats ticks without alerting (known gap; `failure() || cancelled()` is the candidate fix).
+- Runner network weather is real: checkout fetches sometimes hang dead mid-stream (three times on 2026-08-20 alone). Rerun on a fresh runner before redesigning anything; job timeouts exist to bound exactly this.
 
 ## Design decisions (settled — don't re-litigate)
 
@@ -39,6 +46,7 @@ Hard-won facts about working on harper.blog. Add yours; keep entries short.
 - `~/workspace` symlinks to `~/Public/src` — same repo behind both paths, not two clones.
 - `hugo --quiet` swallows `warnf` output. When debugging templates with `warnf`, build without `--quiet` or the probe looks like it never ran.
 - The dev server's `partialCached` output survives incremental rebuilds AND template touches: a frontmatter change that alters a cached partial's output (e.g. setting `bsky:` on a post — comments.html is cached by `.Title`) won't show on the preview until the server restarts. Fresh one-shot builds are correct; restart the server before declaring a cached partial broken.
+- After mise upgrades Go, hugo servers launched from stale shells segfault on the next config reload (inherited GOROOT points at the deleted toolchain). Relaunch via a fresh `mise x -- hugo serve`.
 
 ## Multilingual
 
@@ -52,6 +60,9 @@ Hard-won facts about working on harper.blog. Add yours; keep entries short.
 - `grab_starred_links.py` initializes `FirecrawlApp` and `OpenAI` at module level — importing it in tests without live credentials crashes. Test against source directly, not via import.
 - Registry writes in `grab_micro_posts_fixed.py` are atomic (temp + `os.replace`). `save_url_registry` and `save_content_registry` leave temp files prefixed with the registry filename if interrupted; safe to delete.
 - CI workflow caches `./tools/.script_cache` (dot-prefixed). Code must use `CACHE_DIRECTORY = ".script_cache"` — no dot was the old mismatch that meant every OpenAI call was a cache miss.
+- Note registries live only in `data/notes/` (`processed_urls.json`, `processed_content_hashes.json`; the split copies were merged in PR #180). A registry that fails to parse ABORTS the run (`RegistryCorruptError`) by design — restore the file from git, never regenerate: a fresh registry forgets every published URL and re-posts the whole feed.
+- ruff ≥0.16 ships far more default rules than the old E4/E7/E9/F — `tools/pyproject.toml` pins `[tool.ruff.lint] select` to keep lint scope fixed. Don't "clean up" the pin; removing it detonates ~300 new violations.
+- `git check-ignore` never matches dir-only patterns (`foo/`) for paths absent from disk — "not ignored" for a directory that doesn't exist yet proves nothing. `tools/.gitignore` keeps both `script_cache` (stale pre-rename dir still on disk) and `.script_cache/` (the live cache) deliberately.
 - `grab_micro_posts_fixed.main()`, `grab_starred_links.main()`, `grab_spotify_saved_tracks.main()`, and `grab_read_books.main()` all return `int` and call `sys.exit(main())`. Per-item failures log and continue; run-level failures (auth, feed unreachable, all items failed) exit non-zero so GitHub Actions goes red.
 - `grab_read_books.py` skips any book whose `index.md` exists — content unchecked. python-frontmatter ≥ 1.2 writes str (not bytes), so the old `open(path, "wb")` + `frontmatter.dump` pattern truncated the file then raised, committing zero-byte bundles that blocked re-fetching forever (dormant since April, activated by the 2026-08-14 dep upgrade). Book writes now go through `book_files.write_frontmatter_file` — serialize first, then open. If a zero-byte bundle appears, delete the dir and re-run the goodreads workflow.
 - Spotify revokes refresh tokens now and then (Jul 21 2026: expired, then revoked); the poller then dies nightly with `invalid_grant`, and CI can't re-auth itself (`open_browser=False`). Recover with `cd tools && uv run spotify_reauth.py`, then `gh secret set SPOTIFY_TOKEN_CACHE < tools/.spotify_cache` and re-dispatch — backfill is automatic (full-library pagination, existing tracks skipped). The token is bound to the client id that minted it, so all SPOTIFY_* secrets must come from the same dashboard app.

--- a/layouts/shortcodes/kitco.html
+++ b/layouts/shortcodes/kitco.html
@@ -1,4 +1,4 @@
 
 {{ if isset .Params "url" }}
-<iframe src="https://kit.co/embed?url={{ index .Params "url" }}" style="display: block; border: 0px; margin: 0 auto; width: 100%; height: 100vw; max-width: 700px; max-height: 700px" scrolling="no"></iframe>
+<iframe src="https://kit.co/embed?url={{ index .Params "url" }}" class="kitco-embed" scrolling="no"></iframe>
 {{end}}

--- a/tools/add_translation_keys.py
+++ b/tools/add_translation_keys.py
@@ -5,12 +5,11 @@ ABOUTME: A tool to add translationKey to the frontmatter of Hugo content files.
 ABOUTME: This helps with multilingual content by linking translations across languages.
 """
 
-import os
-import sys
 import argparse
-import uuid
 import logging
+import uuid
 from pathlib import Path
+
 import frontmatter
 from slugify import slugify
 

--- a/tools/archive/grab_micro_posts.py
+++ b/tools/archive/grab_micro_posts.py
@@ -1,17 +1,17 @@
-import requests
+import hashlib
+import logging
 import os
 import re
-import hashlib
-import json
 from datetime import datetime
-from bs4 import BeautifulSoup
 from functools import lru_cache
-import html2text
-import frontmatter
-from slugify import slugify
 from urllib.parse import urlparse
+
+import frontmatter
+import html2text
+import requests
+from bs4 import BeautifulSoup
 from dotenv import load_dotenv
-import logging
+from slugify import slugify
 
 # Load environment variables from .env file if it exists
 load_dotenv()
@@ -186,7 +186,7 @@ def get_highest_note_id(hugo_content_dir):
                             except (IndexError, ValueError):
                                 continue
                 except Exception as e:
-                    logging.error(f"Error reading file {os.path.join(root, file)}: {str(e)}")
+                    logging.error(f"Error reading file {os.path.join(root, file)}: {e!s}")
     
     return highest_note_id
 

--- a/tools/archive_old_links.py
+++ b/tools/archive_old_links.py
@@ -16,34 +16,37 @@ import frontmatter
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 logger = logging.getLogger(__name__)
 
+# Archive services whose links are already preserved; internal domains that never need archiving
+ARCHIVE_DOMAINS = ('archive.org', 'archive.is', 'archive.today', 'archive.ph', 'archive.vn')
+INTERNAL_DOMAINS = ('localhost', '127.0.0.1', 'harper.blog', 'nata2.org', 'nata3.org')
+
+def host_matches(hostname, domains):
+    """Check if hostname equals or is a subdomain of any domain — substring checks let look-alike hosts through"""
+    if not hostname:
+        return False
+    host = hostname.lower()
+    return any(host == domain or host.endswith('.' + domain) for domain in domains)
+
 def is_external_link(url):
     """Check if a URL is an external link that needs archiving"""
     if not url:
         return False
-    
+
     # Parse the URL
     parsed = urlparse(url)
-    
+
     # If no scheme or netloc, it's likely a relative link
     if not parsed.scheme or not parsed.netloc:
         return False
-    
-    # Check if it's already an archive.org link
-    if 'archive.org' in parsed.netloc or 'web.archive.org' in parsed.netloc:
+
+    # Check if it's already an archive service link
+    if host_matches(parsed.hostname, ARCHIVE_DOMAINS):
         return False
-    
-    # Check if it's an archive.is or archive.today link
-    if any(domain in parsed.netloc for domain in ['archive.is', 'archive.today', 'archive.ph', 'archive.vn']):
-        return False
-    
-    # List of local/internal domains (customize as needed)
-    internal_domains = ['localhost', '127.0.0.1', 'harper.blog', 'nata2.org', 'nata3.org']
-    
+
     # Check if the domain is internal
-    for domain in internal_domains:
-        if domain in parsed.netloc:
-            return False
-    
+    if host_matches(parsed.hostname, INTERNAL_DOMAINS):
+        return False
+
     return True
 
 def extract_links_from_content(content):
@@ -159,7 +162,7 @@ def process_post(file_path, dry_run=False, summary_only=False):
         for link in links:
             parsed = urlparse(link['url'])
             if parsed.scheme and parsed.netloc:
-                if 'archive.org' in parsed.netloc or 'web.archive.org' in parsed.netloc or any(domain in parsed.netloc for domain in ['archive.is', 'archive.today', 'archive.ph', 'archive.vn']):
+                if host_matches(parsed.hostname, ARCHIVE_DOMAINS):
                     archived_count += 1
                 elif is_external_link(link['url']):
                     external_links.append(link)

--- a/tools/archive_old_links.py
+++ b/tools/archive_old_links.py
@@ -2,15 +2,15 @@
 # ABOUTME: This script audits blog posts that are 10+ years old and replaces external links with archive.org links
 # ABOUTME: It helps preserve content accessibility by preventing link rot in older posts
 
-import os
-import re
-from datetime import datetime, timedelta
 import argparse
-from pathlib import Path
-import frontmatter
-from urllib.parse import urlparse
 import logging
+import re
 import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from urllib.parse import urlparse
+
+import frontmatter
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
@@ -126,7 +126,7 @@ def process_post(file_path, dry_run=False, summary_only=False):
             try:
                 # Remove timezone info for consistent comparison
                 post_date = datetime.fromisoformat(post_date.replace('+00:00', '').replace('Z', ''))
-            except:
+            except:  # noqa: E722 behavioral
                 if not summary_only:
                     logger.warning(f"Could not parse date in {file_path}: {post_date}")
                 return stats
@@ -159,9 +159,7 @@ def process_post(file_path, dry_run=False, summary_only=False):
         for link in links:
             parsed = urlparse(link['url'])
             if parsed.scheme and parsed.netloc:
-                if 'archive.org' in parsed.netloc or 'web.archive.org' in parsed.netloc:
-                    archived_count += 1
-                elif any(domain in parsed.netloc for domain in ['archive.is', 'archive.today', 'archive.ph', 'archive.vn']):
+                if 'archive.org' in parsed.netloc or 'web.archive.org' in parsed.netloc or any(domain in parsed.netloc for domain in ['archive.is', 'archive.today', 'archive.ph', 'archive.vn']):
                     archived_count += 1
                 elif is_external_link(link['url']):
                     external_links.append(link)
@@ -176,9 +174,9 @@ def process_post(file_path, dry_run=False, summary_only=False):
             
             if not external_links:
                 if archived_count > 0:
-                    logger.info(f"  No new external links to archive")
+                    logger.info("  No new external links to archive")
                 else:
-                    logger.info(f"  No external links found")
+                    logger.info("  No external links found")
                 return stats
             
             logger.info(f"  Found {len(external_links)} external links to archive")
@@ -323,7 +321,7 @@ def main():
             if not args.dry_run and not args.summary and stats['updated']:
                 time.sleep(0.5)
     
-    logger.info(f"\nSummary:")
+    logger.info("\nSummary:")
     logger.info(f"  Total posts processed: {processed_count}")
     logger.info(f"  Posts 10+ years old: {old_posts_count}")
     logger.info(f"  Old posts with any links: {posts_with_links}")

--- a/tools/backfill_goodreads_ids.py
+++ b/tools/backfill_goodreads_ids.py
@@ -1,14 +1,15 @@
 # ABOUTME: One-time backfill script that adds goodreads_work_id to book entry frontmatter.
 # ABOUTME: Reads work.id from data/books/*.yaml and writes it into content/books/*/index.md.
 
-import os
+import glob
 import logging
-import yaml
+import os
+from collections import defaultdict
+
 import frontmatter
+import yaml
 
 from book_files import write_frontmatter_file
-import glob
-from collections import defaultdict
 
 logger = logging.getLogger(__name__)
 

--- a/tools/batch_translate.py
+++ b/tools/batch_translate.py
@@ -1,14 +1,13 @@
 # ABOUTME: This script batch translates blog posts using the AICoder Translator tool
 # ABOUTME: It handles page bundles and markdown files for Hugo static site generation
 
-import os
-import sys
-import subprocess
 import argparse
-from pathlib import Path
-from typing import List, Optional, Dict
 import logging
 import shutil
+import subprocess
+import sys
+from pathlib import Path
+
 
 def setup_logging(verbose: bool = False) -> None:
     """Configure logging based on verbosity level."""
@@ -19,7 +18,7 @@ def setup_logging(verbose: bool = False) -> None:
         datefmt='%Y-%m-%d %H:%M:%S'
     )
 
-def find_translator_binary() -> Optional[str]:
+def find_translator_binary() -> str | None:
     """Find the translator binary in PATH."""
     return shutil.which('translator')
 
@@ -28,7 +27,7 @@ def validate_language(language: str) -> bool:
     # Simple check - language should be alphabetic and reasonable length
     return language.isalpha() and 2 <= len(language) <= 20
 
-def get_output_filename(input_file: Path, language: str, output_dir: Optional[Path] = None) -> Path:
+def get_output_filename(input_file: Path, language: str, output_dir: Path | None = None) -> Path:
     """Generate output filename based on language and optional output directory."""
     if output_dir:
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -38,8 +37,8 @@ def get_output_filename(input_file: Path, language: str, output_dir: Optional[Pa
         return input_file.parent / f"{input_file.stem}.{language.lower()}.md"
 
 def translate_file(file_path: Path, language: str, translator_binary: str, 
-                  output_dir: Optional[Path] = None, dry_run: bool = False,
-                  translator_args: Optional[List[str]] = None) -> bool:
+                  output_dir: Path | None = None, dry_run: bool = False,
+                  translator_args: list[str] | None = None) -> bool:
     """Translate a single file using the translator tool."""
     logger = logging.getLogger(__name__)
     
@@ -82,7 +81,7 @@ def translate_file(file_path: Path, language: str, translator_binary: str,
         logger.error(f"Unexpected error translating {file_path.name}: {e}")
         return False
 
-def find_page_bundles(content_dir: Path) -> List[Path]:
+def find_page_bundles(content_dir: Path) -> list[Path]:
     """Find all page bundles (directories with index.md) in content directory."""
     bundles = []
     
@@ -94,7 +93,7 @@ def find_page_bundles(content_dir: Path) -> List[Path]:
     
     return bundles
 
-def find_markdown_files(paths: List[str], include_bundles: bool = True) -> List[Path]:
+def find_markdown_files(paths: list[str], include_bundles: bool = True) -> list[Path]:
     """Find all markdown files in the given paths."""
     files = []
     

--- a/tools/book_files.py
+++ b/tools/book_files.py
@@ -1,9 +1,10 @@
 # ABOUTME: Shared writer for book index.md files across the goodreads tools.
 # ABOUTME: Serializes before opening so a failed dump never truncates or leaves a zero-byte file.
 
-import frontmatter
 import os
 import tempfile
+
+import frontmatter
 
 
 def write_frontmatter_file(post, path):

--- a/tools/check_contrast.py
+++ b/tools/check_contrast.py
@@ -22,7 +22,7 @@ DEFAULT_THEMES_CSS = REPO / "assets/css/themes.css"
 def parse_blocks(text):
     """Yield (selector, in_dark_media, {var: value}) for each rule block."""
     out = []
-    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
     i, n = 0, len(text)
     media_stack = []
     in_dark = False

--- a/tools/check_feeds.py
+++ b/tools/check_feeds.py
@@ -1,0 +1,104 @@
+# ABOUTME: Validates RSS feeds in a built Hugo site: well-formed XML, item presence,
+# ABOUTME: date parseability, and that every expected feed path actually exists.
+
+"""Usage: uv run check_feeds.py <built-site-dir>
+
+Checks each expected RSS feed for: well-formed XML, at least one <item>, every
+item has <link> and a parseable <pubDate>, and channel <lastBuildDate> is
+parseable when present.
+
+Exits 1 with one line per finding, 0 when all feeds are clean.
+"""
+
+import sys
+import xml.etree.ElementTree as ET
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+
+# The six feeds verified against a production build — missing = incident.
+FEED_PATHS = [
+    "index.xml",
+    "photos/index.xml",
+    "media/books/index.xml",
+    "media/links/index.xml",
+    "media/music/index.xml",
+    "notes/index.xml",
+]
+
+
+def _parse_date(value: str) -> bool:
+    """Return True if value is a parseable RFC 2822 date, False otherwise."""
+    try:
+        parsedate_to_datetime(value)
+        return True
+    except Exception:
+        return False
+
+
+def check_feed(path: Path) -> list[str]:
+    """Check one RSS feed file; return problem strings (empty list = healthy)."""
+    problems: list[str] = []
+
+    try:
+        tree = ET.parse(path)
+    except ET.ParseError as exc:
+        return [f"{path}: XML parse error: {exc}"]
+
+    root = tree.getroot()
+    channel = root.find("channel")
+    if channel is None:
+        return [f"{path}: no <channel> element"]
+
+    # lastBuildDate is optional but must parse when present.
+    last_build = channel.findtext("lastBuildDate")
+    if last_build is not None and not _parse_date(last_build):
+        problems.append(f"{path}: unparseable <lastBuildDate>: {last_build!r}")
+
+    items = channel.findall("item")
+    if not items:
+        problems.append(f"{path}: no <item> elements")
+        return problems
+
+    for i, item in enumerate(items):
+        link = item.findtext("link")
+        if not link:
+            problems.append(f"{path}: item[{i}] missing <link>")
+
+        pub_date = item.findtext("pubDate")
+        if pub_date is None:
+            problems.append(f"{path}: item[{i}] missing <pubDate>")
+        elif not _parse_date(pub_date):
+            problems.append(f"{path}: item[{i}] unparseable <pubDate>: {pub_date!r}")
+
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    """Check all expected feeds under the built-site directory; return 0 = clean, 1 = problems."""
+    if not argv:
+        print("usage: check_feeds.py <built-site-dir>", file=sys.stderr)
+        return 1
+
+    site_dir = Path(argv[0])
+    all_problems: list[str] = []
+
+    for rel in FEED_PATHS:
+        feed_path = site_dir / rel
+        if not feed_path.exists():
+            all_problems.append(f"MISSING: {feed_path}")
+        else:
+            all_problems.extend(check_feed(feed_path))
+
+    for problem in all_problems:
+        print(problem)
+
+    if all_problems:
+        print(f"\n{len(all_problems)} feed problem(s).", file=sys.stderr)
+        return 1
+
+    print("feeds clean: all 6 feeds well-formed with items and valid dates.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/check_inline_styles.py
+++ b/tools/check_inline_styles.py
@@ -1,0 +1,65 @@
+# ABOUTME: Audits Hugo layouts/ for inline style= attributes and <style> blocks that
+# ABOUTME: production CSP (style-src 'self') silently kills — these are dead on Netlify.
+
+"""Usage: uv run check_inline_styles.py
+
+Scans layouts/**/*.html for:
+  - style="..." attributes
+  - <style> blocks
+
+Skips content inside Go template comments ({{/* ... */}}).
+
+Exits 1 with file:line hits, 0 when all templates are clean.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Repo root is two levels up from this file (tools/check_inline_styles.py).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LAYOUTS_ROOT = _REPO_ROOT / "layouts"
+
+# Match Go template block comments: {{/* ... */}} — may span multiple lines.
+_GO_COMMENT_RE = re.compile(r"\{\{/\*.*?\*/\}\}", re.DOTALL)
+
+# Patterns that signal a CSP-blocked inline style.
+_STYLE_ATTR_RE = re.compile(r'\bstyle\s*=\s*["\']', re.IGNORECASE)
+_STYLE_TAG_RE = re.compile(r"<style[\s>]", re.IGNORECASE)
+
+
+def scan_layouts(layouts_root: Path) -> list[str]:
+    """Scan layouts_root/**/*.html for inline styles; return 'file:line: snippet' strings."""
+    hits: list[str] = []
+
+    for html_file in sorted(layouts_root.rglob("*.html")):
+        text = html_file.read_text(encoding="utf-8")
+
+        # Strip Go template comments so their content doesn't trigger false positives.
+        cleaned = _GO_COMMENT_RE.sub("", text)
+
+        for lineno, line in enumerate(cleaned.splitlines(), start=1):
+            if _STYLE_ATTR_RE.search(line) or _STYLE_TAG_RE.search(line):
+                snippet = line.strip()[:100]
+                hits.append(f"{html_file}:{lineno}: {snippet}")
+
+    return hits
+
+
+def main() -> int:
+    """Scan real layouts/ for inline styles; return 0 = clean, 1 = hits found."""
+    hits = scan_layouts(_LAYOUTS_ROOT)
+
+    for hit in hits:
+        print(hit)
+
+    if hits:
+        print(f"\n{len(hits)} inline-style hit(s) — blocked by production CSP.", file=sys.stderr)
+        return 1
+
+    print("inline styles clean: no style= attributes or <style> blocks in layouts/.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_inline_styles.py
+++ b/tools/check_inline_styles.py
@@ -32,7 +32,7 @@ def scan_layouts(layouts_root: Path) -> list[str]:
     """Scan layouts_root/**/*.html for inline styles; return 'file:line: snippet' strings."""
     hits: list[str] = []
 
-    for html_file in sorted(layouts_root.rglob("*.html")):
+    for html_file in sorted(layouts_root.rglob("*.html")):  # *.xml excluded: RSS inline styles are feed-reader intentional, not CSP-gated
         text = html_file.read_text(encoding="utf-8")
 
         # Strip Go template comments so their content doesn't trigger false positives.

--- a/tools/check_nata2_archive_availability.py
+++ b/tools/check_nata2_archive_availability.py
@@ -2,17 +2,17 @@
 # ABOUTME: This script extracts all nata2.info URLs from blog posts and checks their availability on archive.org
 # ABOUTME: It outputs URLs to a text file and creates a report showing which URLs are archived
 
-import os
-import re
-from pathlib import Path
-import frontmatter
-from urllib.parse import urlparse, quote
-import requests
-import time
-import json
-from datetime import datetime
 import argparse
+import json
 import logging
+import re
+import time
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import urlparse
+
+import frontmatter
+import requests
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
@@ -253,8 +253,7 @@ def main():
     # Write URLs to text file
     output_path = project_root / args.output
     with open(output_path, 'w', encoding='utf-8') as f:
-        for url in sorted(all_urls):
-            f.write(url + '\n')
+        f.writelines(url + '\n' for url in sorted(all_urls))
     logger.info(f"Wrote URL list to: {output_path}")
     
     # Create report structure
@@ -281,7 +280,7 @@ def main():
                 archived_count += 1
                 logger.info(f"  ✓ Archived: {result['archive_url']}")
             else:
-                logger.info(f"  ✗ Not archived")
+                logger.info("  ✗ Not archived")
             
             # Show progress
             if i % 10 == 0:
@@ -291,7 +290,7 @@ def main():
         report['missing_count'] = len(all_urls) - archived_count
         report['archive_percentage'] = round((archived_count / len(all_urls)) * 100, 2) if all_urls else 0
         
-        logger.info(f"\n\nArchive Summary:")
+        logger.info("\n\nArchive Summary:")
         logger.info(f"  Total URLs: {len(all_urls)}")
         logger.info(f"  Archived: {archived_count} ({report['archive_percentage']}%)")
         logger.info(f"  Missing: {report['missing_count']}")

--- a/tools/check_nata2_cdx.py
+++ b/tools/check_nata2_cdx.py
@@ -2,16 +2,16 @@
 # ABOUTME: This script checks nata2.info URLs availability using archive.org CDX API
 # ABOUTME: It's faster than individual checks and provides comprehensive archive data
 
-import os
-import json
-import requests
 import argparse
+import json
 import logging
-from pathlib import Path
-from urllib.parse import urlparse, quote
-import time
+import os
 from collections import defaultdict
 from datetime import datetime
+from pathlib import Path
+from urllib.parse import urlparse
+
+import requests
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 def get_cdx_data(domain="nata2.info"):
     """Fetch CDX data for a domain from archive.org"""
-    cdx_url = f"http://web.archive.org/cdx/search/cdx"
+    cdx_url = "http://web.archive.org/cdx/search/cdx"
     
     # Parameters for the CDX API
     params = {
@@ -74,8 +74,7 @@ def analyze_cdx_data(cdx_data):
     for entry in cdx_data:
         url = entry.get('original', '')
         timestamp = entry.get('timestamp', '')
-        mimetype = entry.get('mimetype', '')
-        
+
         # Extract year from timestamp
         if timestamp and len(timestamp) >= 4:
             year = timestamp[:4]
@@ -236,7 +235,7 @@ def main():
         if check_results:
             report['specific_urls_check'] = check_results
             
-            logger.info(f"\nSpecific URLs Check:")
+            logger.info("\nSpecific URLs Check:")
             logger.info(f"  Total requested: {check_results['total_requested']}")
             logger.info(f"  Found in archive: {check_results['found_count']} ({check_results['coverage_percentage']}%)")
             logger.info(f"  Not found: {check_results['not_found_count']}")

--- a/tools/check_nata2_smart_match.py
+++ b/tools/check_nata2_smart_match.py
@@ -2,16 +2,15 @@
 # ABOUTME: This script smartly matches nata2.info URLs from blog posts with archived URLs
 # ABOUTME: It handles different URL formats and finds the best available archive matches
 
-import os
-import json
-import requests
 import argparse
+import json
 import logging
-from pathlib import Path
-from urllib.parse import urlparse, quote, unquote, parse_qs
-import time
+import os
 from collections import defaultdict
 from datetime import datetime
+from urllib.parse import parse_qs, unquote, urlparse
+
+import requests
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
@@ -265,7 +264,7 @@ def main():
     logger.info("Finding matches...")
     matches, no_matches = find_matches(requested_urls, cdx_data)
     
-    logger.info(f"\nResults:")
+    logger.info("\nResults:")
     logger.info(f"  Matched: {len(matches)} URLs")
     logger.info(f"  Not matched: {len(no_matches)} URLs")
     logger.info(f"  Coverage: {round((len(matches) / len(requested_urls)) * 100, 2)}%")

--- a/tools/check_redirects.py
+++ b/tools/check_redirects.py
@@ -34,17 +34,17 @@ def _page_exists(site_dir: Path, url_path: str) -> bool:
 
 
 def _splat_base(target_pattern: str) -> str:
-    """Return the base path of a splat target pattern.
+    """Return the directory that must exist as a built page for a splat target.
 
-    '/media/books/page/:splat'  →  '/media/books/'
+    '/es/media/books/:splat'    →  '/es/media/books/'
+    '/media/books/page/:splat'  →  '/media/books/'  (Hugo emits no bare
+        /page/ index — the section root is what must survive)
     '/:splat'                   →  '/'
     """
-    # Strip the :splat token and any trailing path segment that held it.
     without_splat = target_pattern.replace(":splat", "").rstrip("/")
-    # Remove the last segment (which is the prefix word like 'page').
-    parts = without_splat.rsplit("/", 1)
-    base = parts[0] + "/" if len(parts) > 1 else "/"
-    return base
+    if without_splat.endswith("/page"):
+        without_splat = without_splat[: -len("/page")]
+    return without_splat + "/"
 
 
 def check_rules(site_dir: Path, redirects_path: Path) -> list[str]:

--- a/tools/check_redirects.py
+++ b/tools/check_redirects.py
@@ -1,0 +1,125 @@
+# ABOUTME: Validates Netlify _redirects rules against a built Hugo site: checks that
+# ABOUTME: redirect targets exist, and that sources don't shadow real content pages.
+
+"""Usage: uv run check_redirects.py <built-site-dir> [redirects-file]
+
+Parses static/_redirects (or a supplied path) and verifies each rule:
+  - Target must exist in the built site (as page dir/index.html or exact file)
+    OR be an external URL (http-prefixed).
+  - Splat rules: the target pattern's base section must exist.
+  - Non-splat source must NOT also exist as a built page (shadowing = bug).
+
+Exits 1 with one line per violation, 0 when all rules are clean.
+"""
+
+import sys
+from pathlib import Path
+
+# Repo root is two levels up from this file (tools/check_redirects.py).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_REDIRECTS = _REPO_ROOT / "static" / "_redirects"
+
+
+def _page_exists(site_dir: Path, url_path: str) -> bool:
+    """Return True if url_path resolves to a page or file in site_dir.
+
+    Accepts:
+      - <site_dir><url_path>/index.html  (directory pages)
+      - <site_dir><url_path>             (exact files like index.xml)
+    """
+    stripped = url_path.lstrip("/")
+    candidate_dir = site_dir / stripped / "index.html"
+    candidate_file = site_dir / stripped
+    return candidate_dir.exists() or (candidate_file.exists() and candidate_file.is_file())
+
+
+def _splat_base(target_pattern: str) -> str:
+    """Return the base path of a splat target pattern.
+
+    '/media/books/page/:splat'  →  '/media/books/'
+    '/:splat'                   →  '/'
+    """
+    # Strip the :splat token and any trailing path segment that held it.
+    without_splat = target_pattern.replace(":splat", "").rstrip("/")
+    # Remove the last segment (which is the prefix word like 'page').
+    parts = without_splat.rsplit("/", 1)
+    base = parts[0] + "/" if len(parts) > 1 else "/"
+    return base
+
+
+def check_rules(site_dir: Path, redirects_path: Path) -> list[str]:
+    """Parse redirects_path and check each rule; return violation strings."""
+    violations: list[str] = []
+
+    text = redirects_path.read_text(encoding="utf-8")
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        parts = line.split()
+        if len(parts) < 2:
+            violations.append(f"{redirects_path}:{lineno}: malformed rule: {line!r}")
+            continue
+
+        source, target = parts[0], parts[1]
+        is_splat = ":splat" in target or "*" in source
+
+        # External targets are always valid — Netlify handles them.
+        if target.startswith("http"):
+            continue
+
+        if is_splat:
+            # For splat rules, verify that the target's base section exists.
+            base = _splat_base(target)
+            if not _page_exists(site_dir, base):
+                violations.append(
+                    f"{redirects_path}:{lineno}: splat target base missing: "
+                    f"{base!r} (rule: {source} → {target})"
+                )
+        else:
+            # For exact rules, target must exist as a page or file.
+            if not _page_exists(site_dir, target):
+                violations.append(
+                    f"{redirects_path}:{lineno}: target not found in built site: "
+                    f"{target!r} (rule: {source} → {target})"
+                )
+
+            # Source must NOT shadow a real built page.
+            if _page_exists(site_dir, source):
+                violations.append(
+                    f"{redirects_path}:{lineno}: source shadows real content: "
+                    f"{source!r} exists as a built page (rule: {source} → {target})"
+                )
+
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    """Check _redirects rules against built site; return 0 = clean, 1 = problems."""
+    if not argv:
+        print("usage: check_redirects.py <built-site-dir> [redirects-file]", file=sys.stderr)
+        return 1
+
+    site_dir = Path(argv[0])
+    redirects_path = Path(argv[1]) if len(argv) > 1 else _DEFAULT_REDIRECTS
+
+    if not redirects_path.exists():
+        print(f"ERROR: _redirects not found: {redirects_path}", file=sys.stderr)
+        return 1
+
+    violations = check_rules(site_dir, redirects_path)
+
+    for v in violations:
+        print(v)
+
+    if violations:
+        print(f"\n{len(violations)} redirect violation(s).", file=sys.stderr)
+        return 1
+
+    print(f"redirects clean: {redirects_path} — all rules valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/check_redirects.py
+++ b/tools/check_redirects.py
@@ -42,8 +42,7 @@ def _splat_base(target_pattern: str) -> str:
     '/:splat'                   →  '/'
     """
     without_splat = target_pattern.replace(":splat", "").rstrip("/")
-    if without_splat.endswith("/page"):
-        without_splat = without_splat[: -len("/page")]
+    without_splat = without_splat.removesuffix("/page")
     return without_splat + "/"
 
 

--- a/tools/check_themes.py
+++ b/tools/check_themes.py
@@ -2,7 +2,6 @@
 # ABOUTME: Checks WCAG contrast ratios and reports potential accessibility issues
 
 import re
-import colorsys
 from pathlib import Path
 
 
@@ -88,7 +87,6 @@ def check_theme(name: str, colors: dict, mode: str) -> list[str]:
     bg = colors.get("color-light", "#ffffff")
     fg = colors.get("color-dark", "#000000")
     link = colors.get("color-link", fg)
-    primary = colors.get("color-primary", fg)
 
     try:
         # Text on background (should be >= 4.5 for AA)

--- a/tools/convert_posts_to_page_bundles.py
+++ b/tools/convert_posts_to_page_bundles.py
@@ -1,9 +1,10 @@
+import logging
 import os
 import re
-import requests
-import logging
 from pathlib import Path
 from urllib.parse import urlparse
+
+import requests
 
 # Centralized logging configuration
 logging.basicConfig(
@@ -20,7 +21,7 @@ def download_image(url: str, output_path: Path) -> bool:
         with open(output_path, 'wb') as f:
             f.write(response.content)
         return True
-    except requests.RequestException as e:
+    except requests.RequestException:
         logging.exception("Failed to download image from %s", url)
         return False
 def process_images(content: str, post_dir: Path) -> str:

--- a/tools/deduplicate_notes.py
+++ b/tools/deduplicate_notes.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
-import os
 import json
 import logging
+import os
 import shutil
 from datetime import datetime
 from pathlib import Path
+
 import frontmatter
-from note_utils import normalize_content, generate_content_hash, get_note_id_from_title
+
+from note_utils import generate_content_hash, get_note_id_from_title, normalize_content
 
 # ABOUTME: This script finds and removes duplicate notes, keeping the most recent version.
 # ABOUTME: It detects duplicates based on content similarity and handles Note ID preservation.

--- a/tools/fix_book_dates.py
+++ b/tools/fix_book_dates.py
@@ -8,11 +8,11 @@ import logging
 import os
 
 import frontmatter
-
-from book_files import write_frontmatter_file
 import requests
 import xmltodict
 import yaml
+
+from book_files import write_frontmatter_file
 
 logger = logging.getLogger(__name__)
 

--- a/tools/fix_empty_dates.py
+++ b/tools/fix_empty_dates.py
@@ -2,9 +2,10 @@
 # ABOUTME: Infers the date from the directory name when frontmatter date is empty.
 
 import glob
-import re
-import frontmatter
 import os
+import re
+
+import frontmatter
 
 from book_files import write_frontmatter_file
 

--- a/tools/grab_micro_posts_fixed.py
+++ b/tools/grab_micro_posts_fixed.py
@@ -1,13 +1,12 @@
 import hashlib
-import html
 import json
 import logging
 import os
 import re
 import tempfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from functools import lru_cache
-from urllib.parse import urlparse, urljoin
+from urllib.parse import urljoin, urlparse
 
 import frontmatter
 import html2text
@@ -16,7 +15,7 @@ from bs4 import BeautifulSoup
 from dotenv import load_dotenv
 from slugify import slugify
 
-from note_utils import normalize_content, generate_content_hash, get_note_id_from_title
+from note_utils import generate_content_hash, normalize_content
 
 # Load environment variables from .env file if it exists
 load_dotenv()
@@ -53,16 +52,16 @@ def parse_feed_date(value):
         datetime: Always timezone-aware, in UTC.
     """
     if value is None:
-        return datetime.now(timezone.utc)
+        return datetime.now(UTC)
     try:
         dt = datetime.fromisoformat(value)
         if dt.tzinfo is None:
             # Naive datetime — feed didn't include an offset; treat as UTC.
-            dt = dt.replace(tzinfo=timezone.utc)
+            dt = dt.replace(tzinfo=UTC)
         return dt
     except (ValueError, TypeError):
         logging.warning(f"Unparseable feed date '{value}', substituting current UTC time")
-        return datetime.now(timezone.utc)
+        return datetime.now(UTC)
 
 
 class RegistryCorruptError(RuntimeError):
@@ -268,7 +267,7 @@ def load_url_registry(data_dir):
         try:
             with open(registry_path, 'r', encoding='utf-8') as f:
                 return json.load(f)
-        except (json.JSONDecodeError, IOError) as e:
+        except (OSError, json.JSONDecodeError) as e:
             logging.error(f"Error loading URL registry: {e}")
             raise RegistryCorruptError(
                 f"{registry_path}: {e} — refusing to run with an empty registry (would recreate existing notes)"
@@ -294,7 +293,7 @@ def save_url_registry(registry, data_dir):
         except Exception:
             os.unlink(tmp_path)
             raise
-    except IOError as e:
+    except OSError as e:
         logging.error(f"Error saving URL registry: {e}")
 
 
@@ -313,7 +312,7 @@ def load_content_registry(data_dir):
         try:
             with open(registry_path, 'r', encoding='utf-8') as f:
                 return json.load(f)
-        except (json.JSONDecodeError, IOError) as e:
+        except (OSError, json.JSONDecodeError) as e:
             logging.error(f"Error loading content registry: {e}")
             raise RegistryCorruptError(
                 f"{registry_path}: {e} — refusing to run with an empty registry (would recreate existing notes)"
@@ -339,7 +338,7 @@ def save_content_registry(registry, data_dir):
         except Exception:
             os.unlink(tmp_path)
             raise
-    except IOError as e:
+    except OSError as e:
         logging.error(f"Error saving content registry: {e}")
 
 
@@ -525,7 +524,7 @@ def scan_existing_notes(hugo_content_dir):
                             except (IndexError, ValueError):
                                 continue
                 except Exception as e:
-                    logging.error(f"Error reading file {os.path.join(root, file)}: {str(e)}")
+                    logging.error(f"Error reading file {os.path.join(root, file)}: {e!s}")
     
     return highest_note_id, note_id_map, existing_note_ids
 
@@ -740,7 +739,6 @@ def create_hugo_content(entry, output_dir, url_registry, content_registry, data_
 def main():
     """Main function to process microblog entries. Returns 0 on success, 1 on failure."""
     import argparse
-    import sys as _sys
 
     # Set up command line arguments
     parser = argparse.ArgumentParser(description='Process microblog entries and create Hugo content')

--- a/tools/grab_read_books.py
+++ b/tools/grab_read_books.py
@@ -1,24 +1,23 @@
-from __future__ import print_function
 
 import datetime
+import glob
+import json
+import logging
+import os
+import shutil
+from json import dumps, loads
+
+import frontmatter
+import requests
+import xmltodict
+import yaml
+from dotenv import load_dotenv
+from goodreads import review
 from openai import OpenAI
 from pydantic import BaseModel
-from typing import List
-import json
-import glob
-import os
-import requests
-import logging
-import yaml
-import shutil
 from slugify import slugify
-from dotenv import load_dotenv
-import xmltodict
-from pprint import pprint
-import frontmatter
+
 from book_files import write_frontmatter_file
-from goodreads import review
-from json import loads, dumps
 
 load_dotenv()
 
@@ -83,7 +82,7 @@ def get_book_summary(book_metadata):
         logging.info("Successfully received response from OpenAI API")
         logging.debug(f"Full API response: {response}")
     except Exception as e:
-        logging.error(f"Error occurred while calling OpenAI API: {str(e)}")
+        logging.error(f"Error occurred while calling OpenAI API: {e!s}")
         raise
 
     logging.info("Extracting tags from API response")
@@ -91,16 +90,16 @@ def get_book_summary(book_metadata):
     try:
         result = json.loads(response.choices[0].message.content)
     except json.JSONDecodeError as e:
-        logging.error(f"Failed to parse JSON from API response: {str(e)}")
+        logging.error(f"Failed to parse JSON from API response: {e!s}")
         raise
     except AttributeError as e:
-        logging.error(f"Unexpected API response structure: {str(e)}")
+        logging.error(f"Unexpected API response structure: {e!s}")
         raise
     except IndexError:
         logging.error("API response does not contain any choices")
         raise
     except Exception as e:
-        logging.error(f"Unexpected error while processing API response: {str(e)}")
+        logging.error(f"Unexpected error while processing API response: {e!s}")
         raise
 
     if not isinstance(result, dict):
@@ -182,13 +181,13 @@ def downloadAmazonImage(asin: str, book: dict, url: str, image_filename: str) ->
             return  # Exit after successful download
 
         except requests.exceptions.RequestException as e:
-            logging.error(f"Failed to download image: {str(e)}")
+            logging.error(f"Failed to download image: {e!s}")
             continue
-        except IOError as e:
-            logging.error(f"Failed to save image file: {str(e)}")
+        except OSError as e:
+            logging.error(f"Failed to save image file: {e!s}")
             continue
         except Exception as e:
-            logging.error(f"Unexpected error downloading image: {str(e)}")
+            logging.error(f"Unexpected error downloading image: {e!s}")
             continue
 
     logging.warning(f"Failed to download image for {book['title']} in any size")
@@ -228,7 +227,7 @@ def fix_date(date_string: str) -> str:
         logging.debug(f"Successfully converted date to ISO format: {iso_date}")
         return iso_date
     except ValueError as e:
-        logging.error(f"Failed to parse date string '{date_string}': {str(e)}")
+        logging.error(f"Failed to parse date string '{date_string}': {e!s}")
         return ""
 
 
@@ -268,7 +267,7 @@ def get_goodreads_book(id: str) -> dict:
         logging.error("Request timed out")
         raise
     except requests.exceptions.RequestException as e:
-        logging.error(f"Request failed: {str(e)}")
+        logging.error(f"Request failed: {e!s}")
         logging.debug(
             f"Response content: {resp.content[:500] if resp else 'No response'}"
         )
@@ -287,7 +286,7 @@ def get_goodreads_book(id: str) -> dict:
         return book
 
     except (xmltodict.expat.ExpatError, KeyError) as e:
-        logging.error(f"Failed to parse API response: {str(e)}")
+        logging.error(f"Failed to parse API response: {e!s}")
         raise
 
 
@@ -339,7 +338,7 @@ def get_goodreads_books(limit: int = 200) -> list:
         logging.error("Request to Goodreads API timed out")
         raise
     except requests.exceptions.RequestException as e:
-        logging.error(f"Failed to fetch books from Goodreads: {str(e)}")
+        logging.error(f"Failed to fetch books from Goodreads: {e!s}")
         logging.debug(
             f"Response content: {resp.content[:500] if resp else 'No response'}"
         )
@@ -357,7 +356,7 @@ def get_goodreads_books(limit: int = 200) -> list:
         reviews = [review.GoodreadsReview(r) for r in res["reviews"]["review"]]
 
     except (xmltodict.expat.ExpatError, KeyError) as e:
-        logging.error(f"Failed to parse API response: {str(e)}")
+        logging.error(f"Failed to parse API response: {e!s}")
         raise
 
     logging.info(f"Successfully fetched {len(reviews)} reviews")
@@ -410,7 +409,7 @@ def get_goodreads_books(limit: int = 200) -> list:
             books.append(book)
 
         except Exception as e:
-            logging.error(f"Error processing book review: {str(e)}")
+            logging.error(f"Error processing book review: {e!s}")
             continue
 
     logging.info(f"Successfully processed {len(books)} books")
@@ -525,7 +524,7 @@ def main():
     try:
         books = get_goodreads_books(limit=15)
     except Exception as e:
-        logging.error(f"Failed to get books from Goodreads: {str(e)}")
+        logging.error(f"Failed to get books from Goodreads: {e!s}")
         return 1
 
     for book in books:
@@ -560,7 +559,7 @@ def main():
                 with open(data_filename, "w", encoding="utf-8") as f:
                     yaml.safe_dump(book_data, f, default_flow_style=False)
             except Exception as e:
-                logging.error(f"Failed processing book data for {book['title']}: {str(e)}")
+                logging.error(f"Failed processing book data for {book['title']}: {e!s}")
                 continue
         else:
             logging.debug(f"Loading existing book data from {data_filename}")
@@ -568,7 +567,7 @@ def main():
                 with open(data_filename, "r", encoding="utf-8") as stream:
                     book_data = yaml.safe_load(stream)
             except Exception as e:
-                logging.error(f"Failed loading book data from {data_filename}: {str(e)}")
+                logging.error(f"Failed loading book data from {data_filename}: {e!s}")
                 continue
 
         os.makedirs(post_directory, exist_ok=True)
@@ -611,7 +610,7 @@ def main():
                             link_related_reads(hugo_book_dir, new_slug, existing)
 
             except Exception as e:
-                logging.error(f"Failed creating post for {book['title']}: {str(e)}")
+                logging.error(f"Failed creating post for {book['title']}: {e!s}")
                 continue
 
         # Download cover image
@@ -622,7 +621,7 @@ def main():
                 try:
                     downloadAmazonImage(asin, book_data, "", image_filename)
                 except Exception as e:
-                    logging.error(f"Failed downloading image for {book['title']}: {str(e)}")
+                    logging.error(f"Failed downloading image for {book['title']}: {e!s}")
 
     logging.info("Main processing completed")
     return 0

--- a/tools/grab_read_books_historical.py
+++ b/tools/grab_read_books_historical.py
@@ -1,24 +1,23 @@
-from __future__ import print_function
 
+import argparse
 import datetime
 import json
-import os
-import requests
 import logging
-import yaml
+import os
 import shutil
 import time
-from slugify import slugify
-from dotenv import load_dotenv
-import xmltodict
+from json import dumps, loads
+
 import frontmatter
+import requests
+import xmltodict
+import yaml
+from diskcache import Cache
+from dotenv import load_dotenv
+from goodreads import review
+from slugify import slugify
 
 from book_files import write_frontmatter_file
-from goodreads import review
-from json import loads, dumps
-from diskcache import Cache
-from typing import List, Dict, Any, Optional
-import argparse
 
 load_dotenv()
 
@@ -71,7 +70,7 @@ def fix_date(date_string: str) -> str:
         logging.debug(f"Successfully converted date to ISO format: {iso_date}")
         return iso_date
     except ValueError as e:
-        logging.warning(f"Failed to parse date string '{date_string}': {str(e)}")
+        logging.warning(f"Failed to parse date string '{date_string}': {e!s}")
         return date_string  # Return original on error
 
 @cache.memoize(expire=604800)  # Cache for one week
@@ -111,7 +110,7 @@ def get_goodreads_book(id: str) -> dict:
         logging.error("Request timed out")
         raise
     except requests.exceptions.RequestException as e:
-        logging.error(f"Request failed: {str(e)}")
+        logging.error(f"Request failed: {e!s}")
         logging.debug(
             f"Response content: {resp.content[:500] if 'resp' in locals() else 'No response'}"
         )
@@ -130,10 +129,10 @@ def get_goodreads_book(id: str) -> dict:
         return book
 
     except (xmltodict.expat.ExpatError, KeyError) as e:
-        logging.error(f"Failed to parse API response: {str(e)}")
+        logging.error(f"Failed to parse API response: {e!s}")
         raise
 
-def get_goodreads_reviews_page(page: int, limit: int = 200) -> List[Dict]:
+def get_goodreads_reviews_page(page: int, limit: int = 200) -> list[dict]:
     """
     Fetches a page of book reviews from Goodreads API.
 
@@ -186,7 +185,7 @@ def get_goodreads_reviews_page(page: int, limit: int = 200) -> List[Dict]:
         logging.error(f"Request to Goodreads API timed out for page {page}")
         raise
     except requests.exceptions.RequestException as e:
-        logging.error(f"Failed to fetch reviews from Goodreads for page {page}: {str(e)}")
+        logging.error(f"Failed to fetch reviews from Goodreads for page {page}: {e!s}")
         logging.debug(
             f"Response content: {resp.content[:500] if 'resp' in locals() else 'No response'}"
         )
@@ -216,10 +215,10 @@ def get_goodreads_reviews_page(page: int, limit: int = 200) -> List[Dict]:
         return reviews
 
     except (xmltodict.expat.ExpatError, KeyError) as e:
-        logging.error(f"Failed to parse API response for page {page}: {str(e)}")
+        logging.error(f"Failed to parse API response for page {page}: {e!s}")
         raise
 
-def process_review(r) -> Dict:
+def process_review(r) -> dict:
     """
     Process a single review into a book dictionary.
     
@@ -266,10 +265,10 @@ def process_review(r) -> Dict:
         return book
 
     except Exception as e:
-        logging.error(f"Error processing book review: {str(e)}")
+        logging.error(f"Error processing book review: {e!s}")
         return None
 
-def get_all_goodreads_books(max_pages: int = 10) -> List[Dict]:
+def get_all_goodreads_books(max_pages: int = 10) -> list[dict]:
     """
     Fetches all books across multiple pages.
     
@@ -368,18 +367,18 @@ def downloadAmazonImage(asin: str, book: dict, url: str, image_filename: str) ->
             return  # Exit after successful download
 
         except requests.exceptions.RequestException as e:
-            logging.error(f"Failed to download image: {str(e)}")
+            logging.error(f"Failed to download image: {e!s}")
             continue
-        except IOError as e:
-            logging.error(f"Failed to save image file: {str(e)}")
+        except OSError as e:
+            logging.error(f"Failed to save image file: {e!s}")
             continue
         except Exception as e:
-            logging.error(f"Unexpected error downloading image: {str(e)}")
+            logging.error(f"Unexpected error downloading image: {e!s}")
             continue
 
     logging.warning(f"Failed to download image for {book['title']} in any size")
 
-def get_book_summary(book_metadata: Dict) -> Dict:
+def get_book_summary(book_metadata: dict) -> dict:
     """
     Create a simple summary from book metadata without relying on OpenAI.
     
@@ -463,7 +462,7 @@ def main():
     try:
         books = get_all_goodreads_books(max_pages=args.pages)
     except Exception as e:
-        logging.error(f"Failed to get books from Goodreads: {str(e)}")
+        logging.error(f"Failed to get books from Goodreads: {e!s}")
         raise
 
     processed_count = 0
@@ -523,7 +522,7 @@ def main():
                     with open(data_filename, "w", encoding="utf-8") as f:
                         yaml.safe_dump(book_data, f, default_flow_style=False)
                 except Exception as e:
-                    logging.error(f"Failed processing book data for {book['title']}: {str(e)}")
+                    logging.error(f"Failed processing book data for {book['title']}: {e!s}")
                     failed_count += 1
                     continue
             else:
@@ -532,7 +531,7 @@ def main():
                     with open(data_filename, "r", encoding="utf-8") as stream:
                         book_data = yaml.safe_load(stream)
                 except Exception as e:
-                    logging.error(f"Failed loading book data from {data_filename}: {str(e)}")
+                    logging.error(f"Failed loading book data from {data_filename}: {e!s}")
                     failed_count += 1
                     continue
 
@@ -563,7 +562,7 @@ def main():
                     write_frontmatter_file(post, post_filename)
 
                 except Exception as e:
-                    logging.error(f"Failed creating post for {book['title']}: {str(e)}")
+                    logging.error(f"Failed creating post for {book['title']}: {e!s}")
                     failed_count += 1
                     continue
 
@@ -575,7 +574,7 @@ def main():
                     try:
                         downloadAmazonImage(asin, book_data, "", image_filename)
                     except Exception as e:
-                        logging.error(f"Failed downloading image for {book['title']}: {str(e)}")
+                        logging.error(f"Failed downloading image for {book['title']}: {e!s}")
 
             processed_count += 1
             logging.info(f"Successfully processed book: {book['title']}")
@@ -584,7 +583,7 @@ def main():
             time.sleep(args.delay)
             
         except Exception as e:
-            logging.error(f"Unexpected error processing book {book.get('title', 'Unknown')}: {str(e)}")
+            logging.error(f"Unexpected error processing book {book.get('title', 'Unknown')}: {e!s}")
             failed_count += 1
             continue
 

--- a/tools/grab_spotify_saved_tracks.py
+++ b/tools/grab_spotify_saved_tracks.py
@@ -1,14 +1,15 @@
+import hashlib
 import html
-import os
-import spotipy
-from spotipy.oauth2 import SpotifyOAuth
-from datetime import datetime
-import frontmatter
 import logging
+import os
+from datetime import datetime
+
+import frontmatter
+import spotipy
+import yaml
 from dotenv import load_dotenv
 from slugify import slugify
-import hashlib
-import yaml
+from spotipy.oauth2 import SpotifyOAuth
 
 # Load environment variables
 load_dotenv()

--- a/tools/grab_starred_links.py
+++ b/tools/grab_starred_links.py
@@ -1,20 +1,20 @@
+import hashlib
 import html
+import logging
 import os
 import socket
-import feedparser
 from datetime import datetime
-import slugify
-import frontmatter
-import hashlib
-from dotenv import load_dotenv
 from email.utils import parsedate_to_datetime
-from firecrawl import FirecrawlApp
-from openai import OpenAI, RateLimitError, APIError
-from pydantic import BaseModel
-from typing import Optional, List
-import logging
-from readabilipy import simple_json_from_html_string
+
+import feedparser
+import frontmatter
+import slugify
 from diskcache import Cache
+from dotenv import load_dotenv
+from firecrawl import FirecrawlApp
+from openai import APIError, OpenAI, RateLimitError
+from pydantic import BaseModel
+from readabilipy import simple_json_from_html_string
 
 # Load environment variables
 load_dotenv()
@@ -30,8 +30,8 @@ HUGO_CONTENT_DIR = os.getenv('LINKS_HUGO_CONTENT_DIR')
 OPENAI_MODEL = os.getenv('OPENAI_MODEL')
 
 class Tags(BaseModel):
-    tags: List[str]
-    summary: Optional[str]
+    tags: list[str]
+    summary: str | None
 
 firecrawler = FirecrawlApp(api_key=os.getenv('FIRECRAWL_API_KEY'))
 
@@ -223,7 +223,7 @@ def scrape_url(url):
         return raw
 
     except Exception as e:
-        logging.error(f"Failed to scrape {url}: {str(e)}")
+        logging.error(f"Failed to scrape {url}: {e!s}")
         # Return empty string rather than None for safer handling
         return ""
 

--- a/tools/merge_note_registries.py
+++ b/tools/merge_note_registries.py
@@ -9,11 +9,11 @@ from pathlib import Path
 import frontmatter
 
 from grab_micro_posts_fixed import (
-    URL_REGISTRY_FILENAME,
     CONTENT_REGISTRY_FILENAME,
+    URL_REGISTRY_FILENAME,
     normalize_url,
-    save_url_registry,
     save_content_registry,
+    save_url_registry,
 )
 
 logging.basicConfig(
@@ -78,7 +78,7 @@ def _load_json(path: Path) -> dict:
     try:
         with open(path, "r", encoding="utf-8") as f:
             return json.load(f)
-    except (json.JSONDecodeError, IOError) as e:
+    except (OSError, json.JSONDecodeError) as e:
         logging.error(f"Could not load {path}: {e}")
         return {}
 

--- a/tools/migrate_nata2_content.py
+++ b/tools/migrate_nata2_content.py
@@ -2,19 +2,17 @@
 # ABOUTME: This script migrates old nata2.info content to page bundles with local resources
 # ABOUTME: It finds nata2.info links/images, downloads them from archive.org, and creates page bundles
 
+import argparse
+import hashlib
+import logging
 import os
 import re
-import shutil
 from datetime import datetime
-import argparse
 from pathlib import Path
+from urllib.parse import quote, urlparse
+
 import frontmatter
-from urllib.parse import urlparse, urljoin, quote
-import logging
-import time
 import requests
-from bs4 import BeautifulSoup
-import hashlib
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
@@ -272,12 +270,10 @@ def download_resource(archive_url, local_path):
         if not any(valid_type in content_type for valid_type in valid_types):
             # Check if it's HTML (might be a wayback machine page)
             if 'text/html' in content_type:
-                logger.warning(f"    Got HTML instead of media file, might be a wayback wrapper")
-                # Try to extract the actual image URL from the HTML
-                html_content = response.text
+                logger.warning("    Got HTML instead of media file, might be a wayback wrapper")
                 if 'pictures/misc/phone_camera' in archive_url:
                     # This looks like a phone camera image, let's try a different approach
-                    logger.info(f"    Attempting alternative download method for phone camera image")
+                    logger.info("    Attempting alternative download method for phone camera image")
                 return False
         
         # Save to local file
@@ -292,14 +288,14 @@ def download_resource(archive_url, local_path):
             with open(local_path, 'rb') as f:
                 first_bytes = f.read(100)
                 if b'<!DOCTYPE' in first_bytes or b'<html' in first_bytes:
-                    logger.error(f"    Downloaded file appears to be HTML, not media")
+                    logger.error("    Downloaded file appears to be HTML, not media")
                     local_path.unlink()
                     return False
             
             logger.info(f"    Downloaded: {local_path.name} ({local_path.stat().st_size} bytes)")
             return True
         else:
-            logger.error(f"    Downloaded file is empty or missing")
+            logger.error("    Downloaded file is empty or missing")
             if local_path.exists():
                 local_path.unlink()
             return False
@@ -348,7 +344,7 @@ def convert_to_page_bundle(post_path, resources, dry_run=False):
     if isinstance(post_date, str):
         try:
             post_date = datetime.fromisoformat(post_date.replace('+00:00', '').replace('Z', ''))
-        except:
+        except:  # noqa: E722 behavioral
             post_date = None
     elif hasattr(post_date, 'date'):
         post_date = post_date.replace(tzinfo=None)
@@ -367,7 +363,7 @@ def convert_to_page_bundle(post_path, resources, dry_run=False):
         # Get archive URL (will rewrite URL internally if needed)
         archive_url = get_archive_url(resource['url'], post_date)
         if not archive_url:
-            logger.warning(f"    No archive found, skipping resource")
+            logger.warning("    No archive found, skipping resource")
             continue
         logger.info(f"    Archive URL: {archive_url}")
         
@@ -419,7 +415,7 @@ def convert_to_page_bundle(post_path, resources, dry_run=False):
                 })
             else:
                 # Fall back to archive.org link if download fails
-                logger.warning(f"    Falling back to archive.org link")
+                logger.warning("    Falling back to archive.org link")
                 downloaded_resources.append({
                     'original_url': resource['url'],
                     'archive_url': archive_url,
@@ -614,7 +610,7 @@ def main():
                     if response == 'n':
                         break
     
-    logger.info(f"\n\nSummary:")
+    logger.info("\n\nSummary:")
     logger.info(f"  Total posts checked: {processed_count}")
     logger.info(f"  Posts migrated: {migrated_count}")
 

--- a/tools/nata2_archive_summary.py
+++ b/tools/nata2_archive_summary.py
@@ -2,12 +2,11 @@
 # ABOUTME: This script generates a comprehensive summary of nata2.info archive availability
 # ABOUTME: It combines data from multiple sources to create a final report
 
-import json
 import argparse
+import json
 import logging
-from pathlib import Path
-from datetime import datetime
 from collections import defaultdict
+from datetime import datetime
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
@@ -126,40 +125,40 @@ def print_summary(summary):
     
     print(f"\nReport Date: {summary['report_date']}")
     
-    print(f"\n📊 OVERVIEW")
+    print("\n📊 OVERVIEW")
     print(f"  Total URLs in blog posts: {summary['overview']['total_urls_in_posts']}")
     print(f"  Unique hosts: {summary['overview']['unique_hosts']}")
     
     if 'posts_analysis' in summary:
-        print(f"\n📝 POSTS WITH MOST NATA2 URLS")
+        print("\n📝 POSTS WITH MOST NATA2 URLS")
         for post in summary['posts_analysis']['posts_breakdown'][:5]:
             print(f"  • {post['title'][:50]:<50} ({post['url_count']} URLs)")
     
     if 'archive_coverage' in summary:
-        print(f"\n🗄️  ARCHIVE.ORG COVERAGE")
+        print("\n🗄️  ARCHIVE.ORG COVERAGE")
         print(f"  Total archived URLs: {summary['archive_coverage']['total_archived_urls']:,}")
-        print(f"  By type:")
+        print("  By type:")
         for typ, count in summary['archive_coverage']['archive_by_type'].items():
             print(f"    - {typ}: {count:,}")
     
     if 'matching_results' in summary:
-        print(f"\n🔍 MATCHING RESULTS")
+        print("\n🔍 MATCHING RESULTS")
         print(f"  Matched: {summary['matching_results']['total_matched']} URLs")
         print(f"  Unmatched: {summary['matching_results']['total_unmatched']} URLs")
         print(f"  Coverage: {summary['matching_results']['coverage_percentage']}%")
         
         if summary['matching_results']['match_types']:
-            print(f"  Match types:")
+            print("  Match types:")
             for typ, count in summary['matching_results']['match_types'].items():
                 print(f"    - {typ}: {count}")
     
     if summary.get('unmatched_samples'):
-        print(f"\n❌ SAMPLE UNMATCHED URLS (first 5)")
+        print("\n❌ SAMPLE UNMATCHED URLS (first 5)")
         for url in summary['unmatched_samples'][:5]:
             print(f"  • {url}")
     
     if summary.get('recommendations'):
-        print(f"\n💡 RECOMMENDATIONS")
+        print("\n💡 RECOMMENDATIONS")
         for rec in summary['recommendations']:
             print(f"  [{rec['priority'].upper()}] {rec['action']}")
             print(f"         {rec['detail']}")

--- a/tools/note_utils.py
+++ b/tools/note_utils.py
@@ -1,8 +1,8 @@
 # ABOUTME: Shared utilities for note/micro-post processing across tools.
 # ABOUTME: Contains content normalization, hashing, and note ID extraction.
 
-import re
 import hashlib
+import re
 
 
 def normalize_content(content):

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -28,7 +28,11 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    "ruff>=0.9",
 ]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/tools/rename_book_dirs.py
+++ b/tools/rename_book_dirs.py
@@ -1,11 +1,11 @@
 # ABOUTME: One-time script to rename 2025-02-25-* book directories to match corrected frontmatter dates.
 # ABOUTME: Also renames matching data/books/*.yaml files.
 
-import os
-import glob
 import datetime
+import glob
 import logging
-import shutil
+import os
+
 import frontmatter
 
 from book_files import write_frontmatter_file

--- a/tools/rename_posts.py
+++ b/tools/rename_posts.py
@@ -1,15 +1,13 @@
-import os
-import re
 import hashlib
-import frontmatter
 import logging
-import requests
-from slugify import slugify
-import sys
-from datetime import datetime
-from pathlib import Path
+import os
 from functools import lru_cache
+from pathlib import Path
+
+import frontmatter
+import requests
 from dotenv import load_dotenv
+from slugify import slugify
 
 # Load environment variables from .env file if it exists
 load_dotenv()

--- a/tools/tests/test_archive_old_links.py
+++ b/tools/tests/test_archive_old_links.py
@@ -1,0 +1,31 @@
+# ABOUTME: Tests for archive_old_links.py host classification (archive services vs external links).
+# ABOUTME: Exercises host_matches/is_external_link against exact domains, subdomains, and look-alike hosts.
+
+import archive_old_links
+
+
+def test_archive_domains_match_exact_and_subdomain():
+    assert archive_old_links.host_matches('archive.org', archive_old_links.ARCHIVE_DOMAINS)
+    assert archive_old_links.host_matches('web.archive.org', archive_old_links.ARCHIVE_DOMAINS)
+    assert archive_old_links.host_matches('archive.ph', archive_old_links.ARCHIVE_DOMAINS)
+
+
+def test_lookalike_hosts_rejected():
+    assert not archive_old_links.host_matches('evil-archive.org.attacker.com', archive_old_links.ARCHIVE_DOMAINS)
+    assert not archive_old_links.host_matches('notarchive.org', archive_old_links.ARCHIVE_DOMAINS)
+    assert not archive_old_links.host_matches('archive.org.evil.com', archive_old_links.ARCHIVE_DOMAINS)
+
+
+def test_empty_and_case_handled():
+    assert not archive_old_links.host_matches(None, archive_old_links.ARCHIVE_DOMAINS)
+    assert not archive_old_links.host_matches('', archive_old_links.ARCHIVE_DOMAINS)
+    assert archive_old_links.host_matches('WEB.ARCHIVE.ORG', archive_old_links.ARCHIVE_DOMAINS)
+
+
+def test_is_external_link_classification():
+    assert archive_old_links.is_external_link('https://example.com/page')
+    assert not archive_old_links.is_external_link('https://web.archive.org/web/2016/http://example.com')
+    assert not archive_old_links.is_external_link('https://harper.blog/2016/01/01/post/')
+    assert not archive_old_links.is_external_link('/relative/path')
+    # Look-alike external hosts must still be archived
+    assert archive_old_links.is_external_link('https://evil-archive.org.attacker.com/x')

--- a/tools/tests/test_backfill_goodreads_ids.py
+++ b/tools/tests/test_backfill_goodreads_ids.py
@@ -3,11 +3,16 @@
 
 import os
 import tempfile
-import yaml
-import frontmatter
-import pytest
 
-from backfill_goodreads_ids import get_work_id_from_data_file, backfill_work_ids, detect_and_link_rereads, check_is_reread
+import frontmatter
+import yaml
+
+from backfill_goodreads_ids import (
+    backfill_work_ids,
+    check_is_reread,
+    detect_and_link_rereads,
+    get_work_id_from_data_file,
+)
 
 
 def test_get_work_id_from_data_file():

--- a/tools/tests/test_book_files.py
+++ b/tools/tests/test_book_files.py
@@ -34,7 +34,9 @@ def test_failed_serialization_creates_no_file(tmp_path):
 
 
 def test_write_frontmatter_file_is_atomic(tmp_path):
-    import inspect, book_files
+    import inspect
+
+    import book_files
     src = inspect.getsource(book_files.write_frontmatter_file)
     assert "os.replace(" in src  # temp-file + rename, no in-place open("w")
 

--- a/tools/tests/test_check_feeds.py
+++ b/tools/tests/test_check_feeds.py
@@ -1,10 +1,7 @@
 # ABOUTME: Tests for the check_feeds.py feed-validity checker.
 # ABOUTME: Exercises check_feed() for healthy/broken/empty XML and main() missing-feed guard.
 
-from pathlib import Path
 import textwrap
-
-import pytest
 
 
 HEALTHY_FEED = textwrap.dedent("""\
@@ -64,7 +61,7 @@ def test_check_feed_broken_xml(tmp_path):
 
     import check_feeds
     problems = check_feeds.check_feed(f)
-    assert len(problems) == 1
+    assert len(problems) >= 1
     assert "parse" in problems[0].lower() or "xml" in problems[0].lower()
 
 

--- a/tools/tests/test_check_feeds.py
+++ b/tools/tests/test_check_feeds.py
@@ -3,7 +3,6 @@
 
 import textwrap
 
-
 HEALTHY_FEED = textwrap.dedent("""\
     <?xml version="1.0" encoding="UTF-8"?>
     <rss version="2.0">

--- a/tools/tests/test_check_feeds.py
+++ b/tools/tests/test_check_feeds.py
@@ -1,0 +1,87 @@
+# ABOUTME: Tests for the check_feeds.py feed-validity checker.
+# ABOUTME: Exercises check_feed() for healthy/broken/empty XML and main() missing-feed guard.
+
+from pathlib import Path
+import textwrap
+
+import pytest
+
+
+HEALTHY_FEED = textwrap.dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0">
+      <channel>
+        <title>Test Feed</title>
+        <link>https://example.com</link>
+        <lastBuildDate>Mon, 01 Jan 2024 00:00:00 +0000</lastBuildDate>
+        <item>
+          <title>Post One</title>
+          <link>https://example.com/1</link>
+          <pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate>
+        </item>
+        <item>
+          <title>Post Two</title>
+          <link>https://example.com/2</link>
+          <pubDate>Tue, 02 Jan 2024 00:00:00 +0000</pubDate>
+        </item>
+      </channel>
+    </rss>
+""")
+
+BROKEN_FEED = textwrap.dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0">
+      <channel>
+        <title>Broken Feed</title>
+        <item>
+          <link>https://example.com/1</link>
+    """)  # unclosed tag — not well-formed XML
+
+EMPTY_FEED = textwrap.dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0">
+      <channel>
+        <title>Empty Feed</title>
+        <link>https://example.com</link>
+      </channel>
+    </rss>
+""")  # zero <item> elements
+
+
+def test_check_feed_healthy(tmp_path):
+    """A well-formed feed with 2 items and valid dates returns no problems."""
+    f = tmp_path / "index.xml"
+    f.write_text(HEALTHY_FEED, encoding="utf-8")
+
+    import check_feeds
+    assert check_feeds.check_feed(f) == []
+
+
+def test_check_feed_broken_xml(tmp_path):
+    """An unclosed tag must produce a parse-error problem string."""
+    f = tmp_path / "index.xml"
+    f.write_text(BROKEN_FEED, encoding="utf-8")
+
+    import check_feeds
+    problems = check_feeds.check_feed(f)
+    assert len(problems) == 1
+    assert "parse" in problems[0].lower() or "xml" in problems[0].lower()
+
+
+def test_check_feed_empty_items(tmp_path):
+    """A feed with zero <item> elements must report an item-count problem."""
+    f = tmp_path / "index.xml"
+    f.write_text(EMPTY_FEED, encoding="utf-8")
+
+    import check_feeds
+    problems = check_feeds.check_feed(f)
+    assert len(problems) >= 1
+    assert any("item" in p.lower() for p in problems)
+
+
+def test_main_fails_when_feed_missing(tmp_path):
+    """main() must return 1 when any expected feed file is absent."""
+    import check_feeds
+    # tmp_path has no feed files at all
+    result = check_feeds.main([str(tmp_path)])
+    assert result == 1

--- a/tools/tests/test_check_inline_styles.py
+++ b/tools/tests/test_check_inline_styles.py
@@ -1,0 +1,103 @@
+# ABOUTME: Tests for check_inline_styles.py: detects style= attributes and <style blocks.
+# ABOUTME: Exercises scan_layouts() with tmp layout trees and main() on the real repo.
+
+import textwrap
+from pathlib import Path
+
+
+def _write_template(layouts_dir: Path, rel: str, content: str) -> Path:
+    """Write a template file under layouts_dir."""
+    p = layouts_dir / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(textwrap.dedent(content), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# scan_layouts() unit tests (pure helper, no I/O side effects)
+# ---------------------------------------------------------------------------
+
+def test_clean_template_returns_no_hits(tmp_path):
+    """A template with no inline styles must return an empty hit list."""
+    import check_inline_styles
+
+    layouts = tmp_path / "layouts"
+    _write_template(layouts, "index.html", """\
+        <div class="foo">
+          <p>Hello world</p>
+        </div>
+    """)
+
+    hits = check_inline_styles.scan_layouts(layouts)
+    assert hits == []
+
+
+def test_style_attribute_detected(tmp_path):
+    """A template containing style="..." must appear in scan results."""
+    import check_inline_styles
+
+    layouts = tmp_path / "layouts"
+    _write_template(layouts, "shortcodes/kitco.html", """\
+        <iframe src="https://kit.co/embed?url=x" style="display: block; width: 100%"></iframe>
+    """)
+
+    hits = check_inline_styles.scan_layouts(layouts)
+    assert len(hits) >= 1
+    # hit should reference the file
+    assert any("kitco.html" in h for h in hits)
+
+
+def test_style_block_detected(tmp_path):
+    """A template containing a <style> block must appear in scan results."""
+    import check_inline_styles
+
+    layouts = tmp_path / "layouts"
+    _write_template(layouts, "partials/custom.html", """\
+        <style>
+          .foo { color: red; }
+        </style>
+        <div class="foo">hi</div>
+    """)
+
+    hits = check_inline_styles.scan_layouts(layouts)
+    assert len(hits) >= 1
+    assert any("custom.html" in h for h in hits)
+
+
+def test_go_comment_style_not_detected(tmp_path):
+    """A style= inside a Go template comment {{/* ... */}} must NOT be flagged."""
+    import check_inline_styles
+
+    layouts = tmp_path / "layouts"
+    _write_template(layouts, "index.html", """\
+        {{/* This is a comment with style="example" in it */}}
+        <div>real content</div>
+    """)
+
+    hits = check_inline_styles.scan_layouts(layouts)
+    assert hits == []
+
+
+def test_multiple_files_multiple_hits(tmp_path):
+    """Hits from multiple files must all be returned."""
+    import check_inline_styles
+
+    layouts = tmp_path / "layouts"
+    _write_template(layouts, "a.html", '<span style="color:red">A</span>')
+    _write_template(layouts, "b.html", '<span style="color:blue">B</span>')
+
+    hits = check_inline_styles.scan_layouts(layouts)
+    assert len(hits) >= 2
+
+
+# ---------------------------------------------------------------------------
+# main() contract
+# ---------------------------------------------------------------------------
+
+def test_main_returns_int():
+    """main() must return an int (0 or 1)."""
+    import check_inline_styles
+
+    result = check_inline_styles.main()
+    assert isinstance(result, int)
+    assert result in (0, 1)

--- a/tools/tests/test_check_redirects.py
+++ b/tools/tests/test_check_redirects.py
@@ -1,0 +1,174 @@
+# ABOUTME: Tests for check_redirects.py: valid, broken, and shadowing redirect rules.
+# ABOUTME: Exercises main(argv) with tmp site dirs and tmp _redirects fixture files.
+
+import textwrap
+from pathlib import Path
+
+
+def _write_redirects(tmp_path: Path, content: str) -> Path:
+    """Write a _redirects fixture file and return its path."""
+    p = tmp_path / "_redirects"
+    p.write_text(textwrap.dedent(content), encoding="utf-8")
+    return p
+
+
+def _make_site_page(site_dir: Path, url_path: str) -> None:
+    """Create a built-site page (index.html under url_path) in site_dir."""
+    page = site_dir / url_path.lstrip("/")
+    page.mkdir(parents=True, exist_ok=True)
+    (page / "index.html").write_text("<html></html>", encoding="utf-8")
+
+
+def _make_site_file(site_dir: Path, rel: str) -> None:
+    """Create an exact file in site_dir (e.g. index.xml)."""
+    f = site_dir / rel.lstrip("/")
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("data", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# main() contract: valid rule → exit 0
+# ---------------------------------------------------------------------------
+
+def test_valid_rule_exits_0(tmp_path):
+    """A redirect whose target exists in the built site must exit 0."""
+    import check_redirects
+
+    site_dir = tmp_path / "site"
+    _make_site_page(site_dir, "/media/books/")
+
+    redirects = _write_redirects(tmp_path, """\
+        /books/ /media/books/ 301
+    """)
+
+    result = check_redirects.main([str(site_dir), str(redirects)])
+    assert result == 0
+
+
+def test_external_target_exits_0(tmp_path):
+    """A redirect to an http(s) URL must exit 0 (no local file check)."""
+    import check_redirects
+
+    site_dir = tmp_path / "site"
+    site_dir.mkdir()
+
+    redirects = _write_redirects(tmp_path, """\
+        /old/ https://external.example.com/new/ 301
+    """)
+
+    result = check_redirects.main([str(site_dir), str(redirects)])
+    assert result == 0
+
+
+def test_missing_target_exits_1(tmp_path):
+    """A redirect whose target page is absent from the built site must exit 1."""
+    import check_redirects
+
+    site_dir = tmp_path / "site"
+    site_dir.mkdir()
+
+    redirects = _write_redirects(tmp_path, """\
+        /old/ /new-missing/ 301
+    """)
+
+    result = check_redirects.main([str(site_dir), str(redirects)])
+    assert result == 1
+
+
+def test_shadowing_rule_exits_1(tmp_path):
+    """A redirect whose source URL also exists as a real page must exit 1."""
+    import check_redirects
+
+    site_dir = tmp_path / "site"
+    # Source /books/ exists as a built page AND as a redirect source.
+    _make_site_page(site_dir, "/books/")
+    _make_site_page(site_dir, "/media/books/")
+
+    redirects = _write_redirects(tmp_path, """\
+        /books/ /media/books/ 301
+    """)
+
+    result = check_redirects.main([str(site_dir), str(redirects)])
+    assert result == 1
+
+
+def test_blank_lines_and_comments_ignored(tmp_path):
+    """Blank lines and # comment lines must be skipped without error."""
+    import check_redirects
+
+    site_dir = tmp_path / "site"
+    _make_site_page(site_dir, "/media/books/")
+
+    redirects = _write_redirects(tmp_path, """\
+        # This is a comment
+
+        /books/ /media/books/ 301
+
+    """)
+
+    result = check_redirects.main([str(site_dir), str(redirects)])
+    assert result == 0
+
+
+def test_splat_rule_valid_when_section_exists(tmp_path):
+    """A splat rule is valid when its target base section exists in the built site."""
+    import check_redirects
+
+    site_dir = tmp_path / "site"
+    _make_site_page(site_dir, "/media/books/")
+
+    redirects = _write_redirects(tmp_path, """\
+        /books/page/* /media/books/page/:splat 301
+    """)
+
+    result = check_redirects.main([str(site_dir), str(redirects)])
+    assert result == 0
+
+
+def test_splat_rule_invalid_when_section_missing(tmp_path):
+    """A splat rule whose target base section is absent from the built site must exit 1."""
+    import check_redirects
+
+    site_dir = tmp_path / "site"
+    site_dir.mkdir()
+
+    redirects = _write_redirects(tmp_path, """\
+        /old/page/* /nonexistent/page/:splat 301
+    """)
+
+    result = check_redirects.main([str(site_dir), str(redirects)])
+    assert result == 1
+
+
+def test_missing_redirects_file_exits_1(tmp_path):
+    """main() must return 1 when the _redirects file does not exist."""
+    import check_redirects
+
+    site_dir = tmp_path / "site"
+    site_dir.mkdir()
+
+    result = check_redirects.main([str(site_dir), str(tmp_path / "no_such_file")])
+    assert result == 1
+
+
+def test_missing_site_arg_exits_1():
+    """main([]) with no args must return 1 with a usage message."""
+    import check_redirects
+
+    result = check_redirects.main([])
+    assert result == 1
+
+
+def test_exact_file_target(tmp_path):
+    """A redirect to an exact file (e.g. index.xml) must exit 0 when file exists."""
+    import check_redirects
+
+    site_dir = tmp_path / "site"
+    _make_site_file(site_dir, "/media/books/index.xml")
+
+    redirects = _write_redirects(tmp_path, """\
+        /books/index.xml /media/books/index.xml 301
+    """)
+
+    result = check_redirects.main([str(site_dir), str(redirects)])
+    assert result == 0

--- a/tools/tests/test_check_redirects.py
+++ b/tools/tests/test_check_redirects.py
@@ -125,6 +125,37 @@ def test_splat_rule_valid_when_section_exists(tmp_path):
     assert result == 0
 
 
+def test_splat_rule_direct_section_valid(tmp_path):
+    """A /section/:splat rule verifies the section itself exists."""
+    import check_redirects
+
+    site_dir = tmp_path / "site"
+    _make_site_page(site_dir, "/media/books/")
+
+    redirects = _write_redirects(tmp_path, """\
+        /old/* /media/books/:splat 301
+    """)
+
+    result = check_redirects.main([str(site_dir), str(redirects)])
+    assert result == 0
+
+
+def test_splat_rule_direct_section_missing_exits_1(tmp_path):
+    """A /section/:splat rule must fail when the section is gone, even if its parent exists."""
+    import check_redirects
+
+    site_dir = tmp_path / "site"
+    # Parent /media/ exists; the actual target section /media/books/ does not.
+    _make_site_page(site_dir, "/media/")
+
+    redirects = _write_redirects(tmp_path, """\
+        /old/* /media/books/:splat 301
+    """)
+
+    result = check_redirects.main([str(site_dir), str(redirects)])
+    assert result == 1
+
+
 def test_splat_rule_invalid_when_section_missing(tmp_path):
     """A splat rule whose target base section is absent from the built site must exit 1."""
     import check_redirects

--- a/tools/tests/test_check_redirects.py
+++ b/tools/tests/test_check_redirects.py
@@ -156,6 +156,21 @@ def test_splat_rule_direct_section_missing_exits_1(tmp_path):
     assert result == 1
 
 
+def test_splat_rule_root_target(tmp_path):
+    """A /:splat rule (strip-prefix redirect, e.g. /id/*) validates the site root."""
+    import check_redirects
+
+    site_dir = tmp_path / "site"
+    _make_site_page(site_dir, "/")
+
+    redirects = _write_redirects(tmp_path, """\
+        /id/* /:splat 301
+    """)
+
+    result = check_redirects.main([str(site_dir), str(redirects)])
+    assert result == 0
+
+
 def test_splat_rule_invalid_when_section_missing(tmp_path):
     """A splat rule whose target base section is absent from the built site must exit 1."""
     import check_redirects

--- a/tools/tests/test_dedup_and_ids.py
+++ b/tools/tests/test_dedup_and_ids.py
@@ -11,7 +11,8 @@ def test_shared_prefix_alone_is_not_duplicate(tmp_path):
     # The prefix branch would have returned True (false positive); it must be gone.
     shared_open = "This is a shared opening that happens to be exactl"
     assert len(shared_open) == 50
-    a = tmp_path / "note-a"; a.mkdir()
+    a = tmp_path / "note-a"
+    a.mkdir()
     (a / "index.md").write_text("---\ntitle: a\n---\n" + shared_open + "y fine.")
     new_content = shared_open + " ZZZZ " * 100
     is_dup, _ = gm.is_duplicate_content(new_content, str(tmp_path))

--- a/tools/tests/test_feed_dates.py
+++ b/tools/tests/test_feed_dates.py
@@ -1,6 +1,6 @@
 # ABOUTME: Feed date handling must never mix naive and aware datetimes —
 # ABOUTME: one malformed date_published used to TypeError the whole run.
-from datetime import timezone
+from datetime import UTC
 
 import grab_micro_posts_fixed as gm
 
@@ -11,7 +11,7 @@ def test_parse_feed_date_aware_passthrough():
 
 
 def test_parse_feed_date_naive_becomes_utc():
-    assert gm.parse_feed_date("2025-06-01T12:00:00").tzinfo == timezone.utc
+    assert gm.parse_feed_date("2025-06-01T12:00:00").tzinfo == UTC
 
 
 def test_parse_feed_date_garbage_and_none_are_aware():

--- a/tools/tests/test_fix_book_dates.py
+++ b/tools/tests/test_fix_book_dates.py
@@ -1,12 +1,10 @@
 # ABOUTME: Tests for the one-time fix_book_dates script that corrects wrong 2025-02-25 dates.
 # ABOUTME: Covers offline functions: date map building, book ID extraction, and frontmatter updates.
 
-import os
-import yaml
 import frontmatter
-import pytest
+import yaml
 
-from fix_book_dates import build_date_added_map, get_book_id_from_data_file, fix_dates
+from fix_book_dates import build_date_added_map, fix_dates, get_book_id_from_data_file
 
 
 def test_build_date_added_map_basic():

--- a/tools/tests/test_grab_read_books.py
+++ b/tools/tests/test_grab_read_books.py
@@ -1,7 +1,6 @@
 # ABOUTME: Tests for re-read detection and goodreads_work_id surfacing in the book ingestion script.
 # ABOUTME: Covers metadata creation and re-read scanning logic.
 
-import os
 import frontmatter as fm
 
 from grab_read_books import create_post_metadata
@@ -50,7 +49,7 @@ def test_create_post_metadata_handles_missing_work_id():
     assert metadata["goodreads_work_id"] == ""
 
 
-from grab_read_books import find_existing_reads
+from grab_read_books import find_existing_reads  # noqa: E402 intentional
 
 
 def test_find_existing_reads_finds_match(tmp_path):
@@ -158,11 +157,13 @@ def test_create_post_metadata_falls_back_to_date_added():
     assert metadata["date"] == "2023-06-15T00:00:00-07:00"
 
 
-from grab_read_books import link_related_reads
+from grab_read_books import link_related_reads  # noqa: E402 intentional
 
 
 def test_openai_client_has_timeout():
-    import inspect, grab_read_books
+    import inspect
+
+    import grab_read_books
     assert "OpenAI(timeout=" in inspect.getsource(grab_read_books.get_book_summary)
 
 

--- a/tools/tests/test_merge_note_registries.py
+++ b/tools/tests/test_merge_note_registries.py
@@ -1,6 +1,5 @@
 # ABOUTME: Tests for the one-off registry merge script that heals the
 # ABOUTME: split between data/notes and the abandoned content/data/notes registries.
-from pathlib import Path
 
 from merge_note_registries import merge_registries, sweep_notes_dir
 

--- a/tools/tests/test_registry_guards.py
+++ b/tools/tests/test_registry_guards.py
@@ -1,8 +1,8 @@
 # ABOUTME: Corrupt registries must abort the run (exit non-zero), never
 # ABOUTME: silently reset to empty — an empty registry recreates all notes.
-import pytest
 import sys
-from unittest.mock import patch
+
+import pytest
 
 import grab_micro_posts_fixed as gm
 

--- a/tools/tests/test_security_fixes.py
+++ b/tools/tests/test_security_fixes.py
@@ -8,8 +8,6 @@ import sys
 import tempfile
 
 import frontmatter
-import pytest
-
 
 # ---------------------------------------------------------------------------
 # C2a — frontmatter injection via feed body
@@ -143,7 +141,7 @@ def test_starred_links_main_returns_nonzero_on_missing_env():
     import it in a test environment without credentials.  We test the behavior by calling
     the implementation logic directly via its module globals.
     """
-    import unittest.mock as mock
+    from unittest import mock
     # Use sys.modules trick: provide a fully-mocked module so import succeeds
     fake_module = mock.MagicMock()
     fake_module.RSS_URL = None
@@ -151,7 +149,6 @@ def test_starred_links_main_returns_nonzero_on_missing_env():
 
     # The real check we want: main() in the fixed code returns nonzero when globals are None.
     # Verify the guard logic directly by inspecting the source.
-    import inspect, ast
     source_path = os.path.join(os.path.dirname(__file__), "..", "grab_starred_links.py")
     source = open(source_path).read()
     # Ensure the fixed code uses `return` with a nonzero int (not bare return) on the guard
@@ -272,8 +269,6 @@ def test_books_main_skips_bad_date_and_continues(monkeypatch):
         "num_pages": "100",
     }
 
-    processed = []
-
     monkeypatch.setattr(grab_read_books, "get_goodreads_books", lambda limit=15: [bad_book, good_book])
     # We only want to verify that main() doesn't abort — stub out the heavy work
     original_makedirs = os.makedirs
@@ -283,10 +278,10 @@ def test_books_main_skips_bad_date_and_continues(monkeypatch):
 
     # Just confirm it returns 0 or at least doesn't raise
     # We do a minimal test: bad_book with empty date should be skipped, not crash
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as _:
         monkeypatch.setattr(grab_read_books, "get_goodreads_books", lambda limit=15: [bad_book])
         # Patch directories
-        import unittest.mock as mock
+        from unittest import mock
         with mock.patch("grab_read_books.os.makedirs"):
             # The key check: strptime on empty date must not raise
             from grab_read_books import fix_date

--- a/tools/uv.lock
+++ b/tools/uv.lock
@@ -1355,6 +1355,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.16.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/8f/d8074b1f25e003164087a8bfe79a0f1a3945135764dbb6aaab04103dcaf9/ruff-0.16.4.tar.gz", hash = "sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc", size = 4899731, upload-time = "2026-08-20T17:43:59.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/80/779895ef584e089d22f2c6df0d0e99a65ec2df0805f1fffd439415b8c1f0/ruff-0.16.4-py3-none-linux_armv6l.whl", hash = "sha256:df4075f71ddac40b9934af60c3ec8a53047dd5a5fdc43224e6e4e8e9a27cb6f7", size = 10006909, upload-time = "2026-08-20T17:43:16.888Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e6/f553199b5e8927a05cb5c422d921fd0656b29ab976e91c44802107c6b0da/ruff-0.16.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0c95538517af68004306b0fb3214ff2f2af67a65092aee77cd9eb86db6656604", size = 10240201, upload-time = "2026-08-20T17:43:19.337Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/70/4a6dc4bb34da4dee35e30f09bbd1bfbdd26f33b62fb9b8df31f08a199cd2/ruff-0.16.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:963f83df8e69e575b64d67dd447ebbc917db41a14bf38d4593a4183e7aaa8255", size = 9835122, upload-time = "2026-08-20T17:43:21.708Z" },
+    { url = "https://files.pythonhosted.org/packages/24/12/c6e22d686372c15bcb7af99831f1a1be96df696491babf4f24e4f942c527/ruff-0.16.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32a5057c7ff3f6e6480a48fccfb3a412a690f48a3d03ac5cf08177d6c2da3ade", size = 9977162, upload-time = "2026-08-20T17:43:24.236Z" },
+    { url = "https://files.pythonhosted.org/packages/46/49/72b10ec912f5ab5854992eaf7aa7cd36729b6937d9dc4e0fb41b3bf428ec/ruff-0.16.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3dce8d9b0c57c265b91885a66a567d8ea1372e8eb4e250fa8e5e3f579e99cff", size = 9829789, upload-time = "2026-08-20T17:43:26.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/80/0f30e32e7f6ee26edc39075502db9d368d788a44a79b55f763eb4ab03796/ruff-0.16.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7dc651db49283c69f8e72c834eec4fe5573e4c646856aebece0ce385dceb2a80", size = 10527949, upload-time = "2026-08-20T17:43:29.384Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3d/86e8ad3542169e56cac3859a343afdb9df2ad54d35a59ce1e67baee83421/ruff-0.16.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3817b87dbcabc92f13b05019257c5b89b5b4d51b5fb20f56fb5235ceb723cd07", size = 11333695, upload-time = "2026-08-20T17:43:31.872Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/16/481c29b380c20a0054a8261066665e1b3488e23636c49d0a43e75975b9bb/ruff-0.16.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e9fce1499134b2c8c68e5166f95705a5812062bb93aacc5f9873bb1a27084bc7", size = 10727741, upload-time = "2026-08-20T17:43:34.596Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b6/56bc0b8cf45b54b28b3a5e6381c8945d51b5b18adf659454c32295209a31/ruff-0.16.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3", size = 10286522, upload-time = "2026-08-20T17:43:37.288Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8b/b345b4fb110f2fbe2bd31eabd271e5e8b3b7e4ee6c0e02f2dc6be78db000/ruff-0.16.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6baaf984aa7976edf93d3b627fe2d1d22ee94bbca05fa6f90fc76d73924e3454", size = 10584182, upload-time = "2026-08-20T17:43:39.984Z" },
+    { url = "https://files.pythonhosted.org/packages/29/e5/827b34041c35f58774a9681a4213994c164fc987800f4dddabcf451da0bf/ruff-0.16.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bdfcf0b28662eb890372d50f92c283bb94e67e7635ed93c7fd533970acff7b2b", size = 10134195, upload-time = "2026-08-20T17:43:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/10/d0bffcdd6729b87afc82ba0ef377173356a7dc8e972f5179968cf2fdf98c/ruff-0.16.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b66b02cb9b04f537643cadf5768e5f98dc461890d530cb67113d71c8c76e605d", size = 9825821, upload-time = "2026-08-20T17:43:44.532Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/32/0db2a863b796ca62d83e92a07a3ccf00921b14db02059347576a2fda3d4b/ruff-0.16.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8528bf9a4b291a60bf02ea453511e8ce6215bd2b982ee80405b66b008b6c30a0", size = 10267658, upload-time = "2026-08-20T17:43:46.989Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a0/fbdeb59e48c6261f523e56c8f12e9c08fbe693786595cc7e3959207a9232/ruff-0.16.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fbd85d2875fdd67e833213a651f613bbf25303abf6aa822a5121f4531195678d", size = 10697071, upload-time = "2026-08-20T17:43:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1432,6 +1457,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -1457,7 +1483,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.2" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "ruff", specifier = ">=0.9" },
+]
 
 [[package]]
 name = "tqdm"


### PR DESCRIPTION

Final phase of the robustness plan (`docs/robustness-audit-2026-08-20.md`, phases 1-4 in #180/#181/#182/#184). This one adds the verification layer that keeps the earlier fixes honest.

## What's in it

- **`make check`** — one canonical gate: tools pytest + i18n parity + contrast sweep (`.PHONY` reconciled against the real target list).
- **`tools/check_feeds.py`** — validates the six production feeds in a built site: well-formed XML, parseable dates, non-empty items.
- **`tools/check_redirects.py`** — validates every `static/_redirects` rule against a built site: targets exist, splat bases exist (with Hugo's no-bare-`/page/`-index pagination semantics), sources don't shadow real pages.
- **`tools/check_inline_styles.py`** — CSP gate: fails on `style=`/`<style>` in `layouts/**/*.html`, which production CSP (`style-src` without `unsafe-inline`) silently kills. The one existing hit — the kitco shortcode iframe — moved to `assets/css/shortcodes.css`.
- **`.github/workflows/build-check.yaml`** — CI gate on PRs and main pushes touching layouts/config/assets/static/i18n: pinned hugo 0.164.0 (checksum-verified), production build to /tmp, all three checkers, contrast sweep.
- **ruff for `tools/`** — baseline 76 → 0 across 41 files (mostly unused imports and stray f-prefixes); `Lint` step in tools-tests CI; `make tools-test` = ruff + pytest.

## Notable calls

- **kitco style move is invisible in production**: the only post using the shortcode is `draft: true`, so the production visual diff is zero. The restored embed layout shows in draft-enabled previews.
- **RSS xml layouts keep their 4 inline styles** deliberately — that's feed-reader styling, not browser CSP surface; the checker scans HTML layouts only (documented in the script).
- **The `[tool.ruff.lint]` select pin is load-bearing**: ruff 0.16 broadened its built-in default rules (BLE001/LOG015/SIM/FURB…, 388 hits vs 76). The pin keeps CI deterministic at E4/E7/E9/F.
- **4 lint suppressions**, inventoried in the task report: 2× E722 bare-excepts where narrowing would change behavior, 2× E402 mid-file test imports (parked as cosmetic).
- One lint-driven micro-refactor (`writelines` in `check_nata2_archive_availability.py`) rode along from the pre-pin autofix pass — reviewer-verified harmless.
- **CodeQL caught a real one**: the autofix merged two `elif` arms in `archive_old_links.py`, which attributed the pre-existing substring host checks (`'archive.org' in parsed.netloc`) to this PR — and the check genuinely let look-alike hosts (`evil-archive.org.attacker.com`) skip archiving. Fixed at the root with an exact-domain-or-subdomain predicate on `parsed.hostname` (both call sites), plus 4 new tests.
- **Housekeeping for later** (not in this PR): `tools/script_cache` (undotted) is a stale pre-rename cache dir on disk; delete it and the undotted gitignore entry can go too. The dotted `.script_cache` is the live one (code, CI cache, security test all pin it).

## Verification

- `make check` green: 103 tools tests, i18n 14/14 clean, 450 contrast pairs.
- `ruff check` clean; workflow yaml parses; every build-check step dry-run locally against a real production build, and the hugo checksum step tested end-to-end against the real 0.164.0 release assets.
- **This PR is build-check's first live run** — it should appear alongside tools-tests and check-i18n and pass.
- Process: 11 commits, fresh-implementer-per-task with per-task review, opus whole-branch review before this PR (its one Minor — a missing root-splat unit test — landed as a follow-up commit). Later commits render the plan's lessons into `gotchas.md` and fix the CodeQL finding above.
